### PR TITLE
Add automatic updating of deps.edn

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can try it out easily with this one liner:
 $ clojure -Sdeps '{:deps {olical/depot {:mvn/version "1.3.0"}}}' -m depot.outdated.main
 
 |          Dependency | Current | Latest |
-|---------------------|---------|--------|
+|---------------------+---------+--------|
 | org.clojure/clojure |   1.8.0 |  1.9.0 |
 ```
 
@@ -28,7 +28,7 @@ I'd recommend adding depot as an alias in your own `deps.edn` file, this will al
 $ clojure -Aoutdated -a outdated
 
 |   Dependency | Current | Latest |
-|--------------|---------|--------|
+|--------------+---------+--------|
 | olical/depot |   ..... |  ..... |
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can try it out easily with this one liner:
 $ clojure -Sdeps '{:deps {olical/depot {:mvn/version "1.3.0"}}}' -m depot.outdated.main
 
 |          Dependency | Current | Latest |
-|---------------------+---------+--------|
+|---------------------|---------|--------|
 | org.clojure/clojure |   1.8.0 |  1.9.0 |
 ```
 
@@ -28,8 +28,59 @@ I'd recommend adding depot as an alias in your own `deps.edn` file, this will al
 $ clojure -Aoutdated -a outdated
 
 |   Dependency | Current | Latest |
-|--------------+---------+--------|
+|--------------|---------|--------|
 | olical/depot |   ..... |  ..... |
+```
+
+### Updating `deps.edn`
+
+To automatically update the versions in `deps.edn`, use `--update`.
+
+```bash
+$ clojure -m depot.outdated.main --update
+Updating: deps.edn
+  rewrite-clj {:mvn/version "0.6.0"} -> {:mvn/version "0.6.1"}
+  cider/cider-nrepl {:mvn/version "0.17.0"} -> {:mvn/version "0.18.0"}
+  clj-time {:mvn/version "0.14.4"} -> {:mvn/version "0.15.1"}
+  olical/cljs-test-runner {:sha "5a18d41648d5c3a64632b5fec07734d32cca7671"} -> {:sha "da9710b389782d4637ef114176f6e741225e16f0"}
+```
+
+This will leave any formatting, whitespace, and comments intact. It will update
+both the top level deps and any `:aliases` / `:extra-deps`. To prevent Depot
+from touching certain parts of your `deps.edn`, mark them with the
+`^:depot/ignore` metadata.
+
+``` clojure
+{:deps {...}
+
+ :aliases
+ {;; used for testing against older versions of Clojure
+  :clojure-1.8 ^:depot/ignore {:extra-deps
+                               {org.clojure/clojure {:mvn/version "1.8.0"}}}
+  :clojure-1.9 ^:depot/ignore {:extra-deps
+                               {org.clojure/clojure {:mvn/version "1.9.0"}}}}}
+```
+
+`--update` by default looks for `deps.edn` in the current working directory. You
+can instead pass one or more filenames in explicitly.
+
+``` bash
+$ clojure -m depot.outdated.main --update ../my-project/deps.edn
+```
+
+To check and update the project `deps.edn` as well as the user-wide and
+system-wide configurations, use `--update-all`. Note that the system-wide
+version may require extra permissions.
+
+``` bash
+$ clojure -m depot.outdated.main --update-all
+Updating: /usr/local/lib/clojure/deps.edn
+  org.clojure/tools.deps.alpha {:mvn/version "0.5.452"} -> {:mvn/version "0.5.460"}
+  [ERROR] Permission denied:  /usr/local/lib/clojure/deps.edn
+Updating: /home/arne/.clojure/deps.edn
+  All up to date!
+Updating: deps.edn
+  All up to date!
 ```
 
 ## Existing work
@@ -41,7 +92,6 @@ This project is inspired by [lein-ancient][], it relies on [version-clj][] (by t
 Here's a few things I'd like to add some day, feel free to discuss or suggest more:
 
  * Searching for dependencies.
- * `deps.edn` manipulation like npm with `package.json`.
 
 ## Unlicenced
 

--- a/README.md
+++ b/README.md
@@ -68,21 +68,6 @@ can instead pass one or more filenames in explicitly.
 $ clojure -m depot.outdated.main --update ../my-project/deps.edn
 ```
 
-To check and update the project `deps.edn` as well as the user-wide and
-system-wide configurations, use `--update-all`. Note that the system-wide
-version may require extra permissions.
-
-``` bash
-$ clojure -m depot.outdated.main --update-all
-Updating: /usr/local/lib/clojure/deps.edn
-  org.clojure/tools.deps.alpha {:mvn/version "0.5.452"} -> {:mvn/version "0.5.460"}
-  [ERROR] Permission denied:  /usr/local/lib/clojure/deps.edn
-Updating: /home/arne/.clojure/deps.edn
-  All up to date!
-Updating: deps.edn
-  All up to date!
-```
-
 ## Existing work
 
 This project is inspired by [lein-ancient][], it relies on [version-clj][] (by the same author, [xsc][]) for parsing and comparison of version numbers.

--- a/deps.edn
+++ b/deps.edn
@@ -5,8 +5,8 @@
         version-clj {:mvn/version "0.1.2"}}
  :aliases {:dev {:extra-paths ["dev"]
                  :extra-deps {org.clojure/tools.nrepl {:mvn/version "0.2.13"}
-                              cider/cider-nrepl {:mvn/version "0.18.0"}}
+                              cider/cider-nrepl {:mvn/version "0.17.0"}}
                  :main-opts ["-m" "depot.dev.cider"]}
-           :test {:extra-deps {clj-time {:mvn/version "0.15.1"}
+           :test {:extra-deps {clj-time {:mvn/version "0.14.4"}
                                olical/cljs-test-runner {:git/url "https://github.com/Olical/cljs-test-runner.git"
-                                                        :sha "da9710b389782d4637ef114176f6e741225e16f0"}}}}}
+                                                        :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,12 @@
 {:deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/tools.deps.alpha {:mvn/version "0.5.460"}
         org.clojure/tools.cli {:mvn/version "0.4.1"}
+        rewrite-clj {:mvn/version "0.6.1"}
         version-clj {:mvn/version "0.1.2"}}
  :aliases {:dev {:extra-paths ["dev"]
                  :extra-deps {org.clojure/tools.nrepl {:mvn/version "0.2.13"}
-                              cider/cider-nrepl {:mvn/version "0.17.0"}}
+                              cider/cider-nrepl {:mvn/version "0.18.0"}}
                  :main-opts ["-m" "depot.dev.cider"]}
-           :test {:extra-deps {clj-time {:mvn/version "0.14.4"}
+           :test {:extra-deps {clj-time {:mvn/version "0.15.1"}
                                olical/cljs-test-runner {:git/url "https://github.com/Olical/cljs-test-runner.git"
-                                                        :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}}}}}
+                                                        :sha "da9710b389782d4637ef114176f6e741225e16f0"}}}}}

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -100,11 +100,7 @@
         overrides (:override-deps args-map)
         all-deps (merge (:deps deps-map) (:extra-deps args-map))]
     (->> (for [[lib coord] all-deps
-               :let [_ (prn `(current-latest-map ~lib
-                                                 ~(get overrides lib coord)
-                                                 ~{:consider-types consider-types
-                                                   :deps-map       deps-map}))
-                     outdated (current-latest-map lib
+               :let [outdated (current-latest-map lib
                                                   (get overrides lib coord)
                                                   {:consider-types consider-types
                                                    :deps-map       deps-map})]]

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -1,0 +1,114 @@
+(ns depot.outdated
+  (:require [clojure.java.shell :as sh]
+            [clojure.string :as str]
+            [clojure.tools.deps.alpha :as deps]
+            [clojure.tools.deps.alpha.extensions :as ext]
+            [clojure.tools.deps.alpha.reader :as reader]
+            [clojure.tools.deps.alpha.util.maven :as maven]
+            [version-clj.core :as version])
+  (:import org.eclipse.aether.resolution.VersionRangeRequest))
+
+(def version-types #{:snapshot :qualified :release})
+
+(defn version-type [v]
+  (let [type (-> (version/version->seq v)
+                 (last)
+                 (first))]
+    (cond
+      (= type "snapshot") :snapshot
+      (string? type) :qualified
+      (integer? type) :release
+      :else :unrecognised)))
+
+(defn coord->version-status [lib coord {:keys [mvn/repos mvn/local-repo]}]
+  (let [local-repo (or local-repo maven/default-local-repo)
+        remote-repos (mapv maven/remote-repo repos)
+        system (maven/make-system)
+        session (maven/make-session system local-repo)
+        selected (:mvn/version coord)
+        artifact (maven/coord->artifact lib (assoc coord :mvn/version "[0,)"))
+        versions-req (doto (new VersionRangeRequest)
+                       (.setArtifact artifact)
+                       (.setRepositories remote-repos))
+        versions (->> (.resolveVersionRange system session versions-req)
+                      (.getVersions)
+                      (map str))]
+    {:selected selected
+     :types (group-by version-type versions)}))
+
+(defn find-latest [types consider-types]
+  (let [versions (->> (select-keys types consider-types)
+                      (vals)
+                      (apply concat))]
+    (-> (sort version/version-compare versions)
+        (last))))
+
+(defmulti -current-latest-map (fn [_ coord _] (ext/coord-type coord)))
+
+(defmethod -current-latest-map :default
+  [_ _ _]
+  nil)
+
+(defmethod -current-latest-map :mvn
+  [lib coord {:keys [deps-map consider-types]}]
+  (let [{:keys [types selected]} (coord->version-status lib coord deps-map)
+        latest                   (find-latest types consider-types)]
+    (when (and (not (str/blank? selected))
+               (not (str/blank? latest))
+               (= (version/version-compare latest selected) 1))
+      {"Current" selected
+       "Latest"  latest})))
+
+(defn- parse-git-ls-remote
+  "Returns a map of ref name to the latest sha for that ref name."
+  [s]
+  (let [lines (-> s
+                  (str/trim-newline)
+                  (str/split #"\n"))]
+    (into {}
+          (comp
+           (map (fn [x]
+                  (-> x
+                      (str/triml)
+                      (str/split #"\t")
+                      (reverse)
+                      (vec))))
+           (filter #(= 2 (count %))))
+          lines)))
+
+(defmethod -current-latest-map :git
+  [lib coord _]
+  (let [{:keys [exit out err]} (sh/sh "git" "ls-remote" (:git/url coord))
+        latest-remote-sha (get (parse-git-ls-remote out) "HEAD")]
+    (when (and (= exit 0)
+               (neg? (ext/compare-versions
+                      lib coord (assoc coord :sha latest-remote-sha) {})))
+      {"Current" (:sha coord)
+       "Latest"  latest-remote-sha})))
+
+(defn current-latest-map
+  "Returns a map containing `'Current'` and `'Latest'` if the dependency has a
+  newer version otherwise returns `nil`."
+  [lib coord data]
+  (-current-latest-map lib coord data))
+
+(defn gather-outdated [consider-types aliases]
+  (let [deps-map (-> (reader/clojure-env)
+                     (:config-files)
+                     (reader/read-deps))
+        args-map (deps/combine-aliases deps-map aliases)
+        overrides (:override-deps args-map)
+        all-deps (merge (:deps deps-map) (:extra-deps args-map))]
+    (->> (for [[lib coord] all-deps
+               :let [_ (prn `(current-latest-map ~lib
+                                                 ~(get overrides lib coord)
+                                                 ~{:consider-types consider-types
+                                                   :deps-map       deps-map}))
+                     outdated (current-latest-map lib
+                                                  (get overrides lib coord)
+                                                  {:consider-types consider-types
+                                                   :deps-map       deps-map})]]
+           (when outdated
+             (assoc outdated "Dependency" lib)))
+         (keep identity)
+         (sort-by #(get % "Dependency")))))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -26,7 +26,6 @@
     :parse-fn comma-str->keywords-set
     :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
    ["-u" "--update" "Update deps.edn, or filenames given as additional command line arguments."]
-   [nil  "--update-all" "Update user, system, and project deps.edn"]
    ["-h" "--help"]])
 
 (defn -main [& args]
@@ -44,10 +43,6 @@
         (run! #(depot.outdated.update/update-deps-edn! % consider-types)
               files)
         (depot.outdated.update/update-deps-edn! "deps.edn" consider-types))
-
-      update-all
-      (run! #(depot.outdated.update/update-deps-edn! % consider-types)
-            (:config-files (reader/clojure-env)))
 
       :else
       (let [outdated (depot/gather-outdated consider-types aliases)]

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -2,115 +2,10 @@
   (:require [clojure.pprint :as pprint]
             [clojure.set :as set]
             [clojure.string :as str]
-            [clojure.java.shell :as sh]
             [clojure.tools.cli :as cli]
-            [clojure.tools.deps.alpha :as deps]
-            [clojure.tools.deps.alpha.reader :as reader]
-            [clojure.tools.deps.alpha.util.maven :as maven]
-            [clojure.tools.deps.alpha.extensions :as ext]
-            [version-clj.core :as version])
-  (:import [org.eclipse.aether.resolution VersionRangeRequest]))
-
-(def version-types #{:snapshot :qualified :release})
-
-(defn version-type [v]
-  (let [type (-> (version/version->seq v)
-                 (last)
-                 (first))]
-    (cond
-      (= type "snapshot") :snapshot
-      (string? type) :qualified
-      (integer? type) :release
-      :else :unrecognised)))
-
-(defn coord->version-status [lib coord {:keys [mvn/repos mvn/local-repo]}]
-  (let [local-repo (or local-repo maven/default-local-repo)
-        remote-repos (mapv maven/remote-repo repos)
-        system (maven/make-system)
-        session (maven/make-session system local-repo)
-        selected (:mvn/version coord)
-        artifact (maven/coord->artifact lib (assoc coord :mvn/version "[0,)"))
-        versions-req (doto (new VersionRangeRequest)
-                       (.setArtifact artifact)
-                       (.setRepositories remote-repos))
-        versions (->> (.resolveVersionRange system session versions-req)
-                      (.getVersions)
-                      (map str))]
-    {:selected selected
-     :types (group-by version-type versions)}))
-
-(defn find-latest [types consider-types]
-  (let [versions (->> (select-keys types consider-types)
-                      (vals)
-                      (apply concat))]
-    (-> (sort version/version-compare versions)
-        (last))))
-
-(defmulti -current-latest-map (fn [_ coord _] (ext/coord-type coord)))
-
-(defmethod -current-latest-map :default
-  [_ _ _]
-  nil)
-
-(defmethod -current-latest-map :mvn
-  [lib coord {:keys [deps-map consider-types]}]
-  (let [{:keys [types selected]} (coord->version-status lib coord deps-map)
-        latest                   (find-latest types consider-types)]
-    (when (and (not (str/blank? selected))
-               (not (str/blank? latest))
-               (= (version/version-compare latest selected) 1))
-      {"Current" selected
-       "Latest"  latest})))
-
-(defn- parse-git-ls-remote
-  "Returns a map of ref name to the latest sha for that ref name."
-  [s]
-  (let [lines (-> s
-                  (str/trim-newline)
-                  (str/split #"\n"))]
-    (into {}
-          (comp
-            (map (fn [x]
-                   (-> x
-                       (str/triml)
-                       (str/split #"\t")
-                       (reverse)
-                       (vec))))
-            (filter #(= 2 (count %))))
-          lines)))
-
-(defmethod -current-latest-map :git
-  [lib coord _]
-  (let [{:keys [exit out err]} (sh/sh "git" "ls-remote" (:git/url coord))
-        latest-remote-sha (get (parse-git-ls-remote out) "HEAD")]
-    (when (and (= exit 0)
-               (neg? (ext/compare-versions
-                       lib coord (assoc coord :sha latest-remote-sha) {})))
-      {"Current" (:sha coord)
-       "Latest"  latest-remote-sha})))
-
-(defn current-latest-map
-  "Returns a map containing `'Current'` and `'Latest'` if the dependency has a
-  newer version otherwise returns `nil`."
-  [lib coord data]
-  (-current-latest-map lib coord data))
-
-(defn gather-outdated [consider-types aliases]
-  (let [deps-map (-> (reader/clojure-env)
-                     (:config-files)
-                     (reader/read-deps))
-        args-map (deps/combine-aliases deps-map aliases)
-        overrides (:override-deps args-map)
-        all-deps (merge (:deps deps-map) (:extra-deps args-map))]
-    (->> (for [[lib coord] all-deps
-               :let [outdated (current-latest-map lib
-                                                  (get overrides lib coord)
-                                                  {:consider-types consider-types
-                                                   :deps-map       deps-map})]]
-           (when outdated
-             (assoc outdated "Dependency" lib)))
-         (keep identity)
-         (sort-by #(get % "Dependency")))))
+            [depot.outdated :as depot]
+            [depot.outdated.update]
+            [clojure.tools.deps.alpha.reader :as reader]))
 
 (defn comma-str->keywords-set [comma-str]
   (into #{} (map keyword) (str/split comma-str #",")))
@@ -118,7 +13,7 @@
 (defn keywords-set->comma-str [kws]
   (str/join "," (map name kws)))
 
-(def version-types-str (keywords-set->comma-str version-types))
+(def version-types-str (keywords-set->comma-str depot/version-types))
 
 (def cli-options
   [["-a" "--aliases ALIASES" "Comma list of aliases to use when reading deps.edn"
@@ -129,15 +24,33 @@
     :default #{:release}
     :default-desc "release"
     :parse-fn comma-str->keywords-set
-    :validate [#(set/subset? % version-types) (str "Must be subset of " version-types)]]
+    :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
+   ["-u" "--update" "Update deps.edn, or filenames given as additional command line arguments."]
+   [nil  "--update-all" "Update user, system, and project deps.edn"]
    ["-h" "--help"]])
 
 (defn -main [& args]
-  (let [{{:keys [aliases consider-types help]} :options
+  (let [{{:keys [aliases consider-types help update update-all]} :options
+         files :arguments
          summary :summary} (cli/parse-opts args cli-options)]
-    (if help
-      (println summary)
-      (let [outdated (gather-outdated consider-types aliases)]
+    (cond
+      help
+      (do
+        (println "USAGE: clojure -m depot.outdated.main [OPTIONS] [FILES]\n")
+        (println summary))
+
+      update
+      (if (seq files)
+        (run! #(depot.outdated.update/update-deps-edn! % consider-types)
+              files)
+        (depot.outdated.update/update-deps-edn! "deps.edn" consider-types))
+
+      update-all
+      (run! #(depot.outdated.update/update-deps-edn! % consider-types)
+            (:config-files (reader/clojure-env)))
+
+      :else
+      (let [outdated (depot/gather-outdated consider-types aliases)]
         (if (empty? outdated)
           (println "All up to date!")
           (do (pprint/print-table ["Dependency" "Current" "Latest"] outdated)

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -1,0 +1,99 @@
+(ns depot.outdated.update
+  (:require [clojure.tools.deps.alpha.reader :as reader]
+            [depot.outdated :as depot]
+            [rewrite-clj.zip :as rzip]))
+
+(defn zget [loc key]
+  (rzip/right
+   (rzip/find-value (rzip/down loc) (comp rzip/right rzip/right) key)))
+
+(defn update-loc? [loc]
+  (not (rzip/find loc
+                  rzip/up
+                  (fn [loc]
+                    (:depot/ignore (meta (rzip/sexpr loc)))))))
+
+(defn try-update-artifact [loc consider-types repos]
+  (if (update-loc? loc)
+    (let [artifact (rzip/sexpr loc)
+          coords-loc (rzip/right loc)]
+      (if-let [latest (get (depot/current-latest-map artifact
+                                                     (rzip/sexpr coords-loc)
+                                                     {:consider-types consider-types
+                                                      :deps-map repos})
+                           "Latest")]
+        (if-let [[version-loc version-key]
+                 (or (some-> (zget coords-loc :mvn/version) (vector :mvn/version))
+                     (some-> (zget coords-loc :sha) (vector :sha)))]
+          (do
+            (binding [*print-namespace-maps* false]
+              (println " " artifact (pr-str {version-key (rzip/sexpr version-loc)}) "->" (pr-str {version-key latest})))
+            (rzip/left
+             (rzip/up
+              (rzip/replace version-loc latest))))
+          loc)
+        loc))
+    loc))
+
+(defn update-deps [loc consider-types repos]
+  (rzip/up
+   (loop [loc (rzip/down loc)]
+     (let [loc' (try-update-artifact loc consider-types repos)
+           loc'' (rzip/right (rzip/right loc'))]
+       (if loc''
+         (recur loc'')
+         loc')))))
+
+(defn zmap-vals [loc f & args]
+  (let [loc' (rzip/down loc)]
+    (if loc'
+      (loop [keyloc loc']
+        (let [valloc (apply f (rzip/right keyloc) args)]
+          (if-let [next-keyloc (rzip/right valloc)]
+            (recur next-keyloc)
+            (rzip/up valloc))))
+      loc)))
+
+(declare update-all)
+
+(defn update-aliases
+  "Update all :aliases, expects a loc pointing at the :aliases map."
+  [loc consider-types repos]
+  (zmap-vals loc update-all consider-types repos))
+
+(defn assert= [x y]
+  (when (not= x y)
+    (let [msg `(~'not= ~x ~y)]
+      (throw (ex-info (prn-str msg) {:error msg})))))
+
+(defn update-all [loc consider-types repos]
+  (let [deps-loc (zget loc :deps)
+        loc (if deps-loc
+              (rzip/up (update-deps deps-loc consider-types repos))
+              loc)
+        extra-deps-loc (zget loc :extra-deps)
+        loc (if extra-deps-loc
+              (rzip/up (update-deps extra-deps-loc consider-types repos))
+              loc)
+        aliases-loc (zget loc :aliases)
+        loc (if aliases-loc
+              (rzip/up (update-aliases aliases-loc consider-types repos))
+              loc)]
+    loc))
+
+(defn update-deps-edn! [file consider-types]
+  (println "Updating:" file)
+  (let [deps  (-> (reader/clojure-env)
+                  :config-files
+                  reader/read-deps)
+        repos (select-keys deps [:mvn/repos :mvn/local-repo])
+        loc   (rzip/of-file file)
+        old-deps (slurp file)
+        new-deps (rzip/root-string
+                  (update-all loc consider-types repos))]
+    (if (= old-deps new-deps)
+      (println "  All up to date!")
+      (try
+        (spit file new-deps)
+        (catch java.io.FileNotFoundException e
+          (println "  [ERROR] Permission denied: " file))))))


### PR DESCRIPTION
Use rewrite-clj to parse deps.edn and update dependencies without messing up
people's formatting.

Most of the functionality of depot.outdated.main has been pulled out to
prevent circular namespace dependencies. Main now only does the handling
of command line arguments.