### PR TITLE
Let --update also check :override-deps

### DIFF
--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -97,19 +97,17 @@
   `consider-types` is a set, one of [[depot.outdated/version-types]].
   `repos` is a map with optional keys `:mvn/repos` and `:mvn/local-repo`."
   [loc consider-types repos]
-  (let [deps-loc (zget loc :deps)
-        loc (if deps-loc
-              (rzip/up (update-deps deps-loc consider-types repos))
-              loc)
-        extra-deps-loc (zget loc :extra-deps)
-        loc (if extra-deps-loc
-              (rzip/up (update-deps extra-deps-loc consider-types repos))
-              loc)
-        aliases-loc (zget loc :aliases)
-        loc (if aliases-loc
-              (rzip/up (update-aliases aliases-loc consider-types repos))
-              loc)]
-    loc))
+  (let [update-key (fn [loc k]
+                     (if-let [deps-loc (zget loc k)]
+                       (rzip/up (update-deps deps-loc consider-types repos))
+                       loc))
+        loc (-> loc
+                (update-key :deps)
+                (update-key :extra-deps)
+                (update-key :override-deps))]
+    (if-let [aliases-loc (zget loc :aliases)]
+      (rzip/up (update-aliases aliases-loc consider-types repos))
+      loc)))
 
 (defn update-deps-edn!
   "Destructively update a `deps.edn` file.


### PR DESCRIPTION
We were checking :deps and :extra-deps but not :override-deps. Since the regular
check also considers this key, --update should to.

Note that you can still opt out of updating certain versions with
^:depot/ignore, either on the version map or on the deps map.

Closes #9