### PR TITLE
Fix issues with --update

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((cider-clojure-cli-global-options . "-A:test"))))

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clojure -A:test -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -9,4 +9,5 @@
                  :main-opts ["-m" "depot.dev.cider"]}
            :test {:extra-deps {clj-time {:mvn/version "0.14.4"}
                                olical/cljs-test-runner {:git/url "https://github.com/Olical/cljs-test-runner.git"
-                                                        :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}}}}}
+                                                        :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}
+                               lambdaisland/kaocha {:mvn/version "0.0-266"}}}}}

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -1,7 +1,23 @@
 (ns depot.outdated.update
   (:require [clojure.tools.deps.alpha.reader :as reader]
             [depot.outdated :as depot]
-            [rewrite-clj.zip :as rzip]))
+            [rewrite-clj.zip :as rzip]
+            [clojure.zip :as zip]))
+
+(defn zip-skip-ws
+  "Skip whitespace, comments, and uneval nodes."
+  [loc]
+  (loop [loc loc]
+    (if (and loc
+             (not (rzip/end? loc))
+             (#{:comment :whitespace :newline :comma :uneval} (rzip/tag loc)))
+      (recur (zip/right loc))
+      loc)))
+
+(defn zright
+  "Like [[rewrite-clj.zip/right]], but also skip over uneval nodes"
+  [loc]
+  (some-> loc rzip/right zip-skip-ws))
 
 (defn zget
   "Like [[clojure.core/get]], but for a zipper over a map.
@@ -9,7 +25,7 @@
   Takes and returns a zipper (loc)."
   [loc key]
   (rzip/right
-    (rzip/find-value (rzip/down loc) (comp rzip/right rzip/right) key)))
+   (rzip/find-value (rzip/down loc) (comp zright zright) key)))
 
 (defn update-loc?
   "Should the version at the current position be updated?
@@ -35,7 +51,7 @@
   [loc consider-types repos]
   (if (update-loc? loc)
     (let [artifact (rzip/sexpr loc)
-          coords-loc (rzip/right loc)]
+          coords-loc (zright loc)]
       (if-let [latest (get (depot/current-latest-map artifact
                                                      (rzip/sexpr coords-loc)
                                                      {:consider-types consider-types
@@ -51,8 +67,8 @@
                 (with-print-namespace-maps false
                   (println " " artifact (pr-str {version-key old-version}) "->" (pr-str {version-key latest})))
                 (rzip/left
-                  (rzip/up
-                    (rzip/replace version-loc latest))))))
+                 (rzip/up
+                  (rzip/replace version-loc latest))))))
           loc)
         loc))
     loc))
@@ -62,13 +78,15 @@
 
   `loc` points at the map."
   [loc consider-types repos]
-  (rzip/up
-    (loop [loc (rzip/down loc)]
-      (let [loc' (try-update-artifact loc consider-types repos)
-            loc'' (rzip/right (rzip/right loc'))]
-        (if loc''
-          (recur loc'')
-          loc')))))
+  (if-let [first-key (rzip/down loc)]
+    (rzip/up
+     (loop [loc first-key]
+       (let [loc' (try-update-artifact loc consider-types repos)
+             loc'' (zright (zright loc'))]
+         (if loc''
+           (recur loc'')
+           loc'))))
+    loc))
 
 (defn zmap-vals
   "Given a zipper pointing at a map, apply a tranformation to each value of the
@@ -77,8 +95,8 @@
   (let [loc' (rzip/down loc)]
     (if loc'
       (loop [keyloc loc']
-        (let [valloc (apply f (rzip/right keyloc) args)]
-          (if-let [next-keyloc (rzip/right valloc)]
+        (let [valloc (apply f (zright keyloc) args)]
+          (if-let [next-keyloc (zright valloc)]
             (recur next-keyloc)
             (rzip/up valloc))))
       loc)))
@@ -123,17 +141,19 @@
   `consider-types` is a set, one of [[depot.outdated/version-types]]. "
   [file consider-types]
   (println "Updating:" file)
-  (let [deps  (-> (reader/clojure-env)
-                  :config-files
-                  reader/read-deps)
-        repos (select-keys deps [:mvn/repos :mvn/local-repo])
-        loc   (rzip/of-file file)
+  (let [deps (-> (reader/clojure-env)
+                 :config-files
+                 reader/read-deps)
+
+        repos    (select-keys deps [:mvn/repos :mvn/local-repo])
+        loc      (rzip/of-file file)
         old-deps (slurp file)
-        new-deps (rzip/root-string
-                   (update-all loc consider-types repos))]
-    (if (= old-deps new-deps)
-      (println "  All up to date!")
-      (try
-        (spit file new-deps)
-        (catch java.io.FileNotFoundException e
-          (println "  [ERROR] Permission denied: " file))))))
+        loc'     (update-all loc consider-types repos)
+        new-deps (rzip/root-string loc')]
+    (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
+      (if (= old-deps new-deps)
+        (println "  All up to date!")
+        (try
+          (spit file new-deps)
+          (catch java.io.FileNotFoundException e
+            (println "  [ERROR] Permission denied: " file)))))))

--- a/test/depot/outdated/update_test.clj
+++ b/test/depot/outdated/update_test.clj
@@ -1,0 +1,74 @@
+(ns depot.outdated.update-test
+  (:require [clojure.test :refer :all]
+            [depot.outdated.update :as u]
+            [rewrite-clj.node :as node]
+            [rewrite-clj.zip :as rzip]))
+
+(def CONSIDER_TYPES_RELEASES #{:release})
+(def REPOS {:mvn/repos
+            {"central" {:url "https://repo1.maven.org/maven2/"},
+             "clojars" {:url "https://repo.clojars.org/"}}})
+
+(deftest zip-skip-ws-test
+  (is (= :foo
+         (-> (rzip/of-string "   ,,, ;;;\n#_123 :foo")
+             (u/zip-skip-ws)
+             rzip/sexpr))))
+
+(deftest zget-test
+  (is (= :bar
+         (-> (rzip/edn (node/coerce {:foo :bar
+                                     :bar :baz}))
+             (u/zget :foo)
+             (rzip/sexpr))))
+
+  (is (nil?
+       (-> (rzip/edn (node/coerce {:foo :bar
+                                   :bar :baz}))
+           (u/zget :unkown))))
+
+  (is (= :baz
+         (-> (rzip/of-string "{:foo :bar #_uneval :bar :baz}")
+             (u/zget :bar)
+             (rzip/sexpr)))))
+
+(deftest update-loc?-test
+  (testing "don't update when tagged with :depot/ignore"
+    (is (false? (u/update-loc?
+                 (rzip/find-value (rzip/of-string "{:aliases {:dev ^:depot/ignore {:deps {foo/bar {}}}}} :test {:deps {baz/baq {}}}")
+                                  rzip/next
+                                  'foo/bar)))))
+
+  (testing "do update by default"
+    (is (true? (u/update-loc?
+                (rzip/find-value (rzip/of-string "{:aliases {:dev ^:depot/ignore {:deps {foo/bar {}}}}} :test {:deps {baz/baq {}}}")
+                                 rzip/next
+                                 'baz/baq))))))
+
+(deftest update-deps-test
+  (is (= '{:deps {org.clojure/algo.monads {:mvn/version "0.1.6"}}}
+
+         (-> (rzip/edn (node/coerce '{:deps {org.clojure/algo.monads {:mvn/version "0.1.4"}}}))
+             (rzip/down)
+             (rzip/right)
+             (u/update-deps CONSIDER_TYPES_RELEASES REPOS)
+             (rzip/root)
+             (node/sexpr))))
+
+  (testing "it skips over uneval nodes"
+    (is (= '{:deps {org.clojure/algo.monads {:mvn/version "0.1.6"}}}
+           (-> (rzip/of-string "{:deps {org.clojure/algo.monads #_foo {:mvn/version \"0.1.4\"}}}")
+               (rzip/down)
+               (rzip/right)
+               (u/update-deps CONSIDER_TYPES_RELEASES REPOS)
+               (rzip/root)
+               (node/sexpr)))))
+
+  (testing "it ignores empty maps"
+    (is (= '{:deps {}}
+           (-> (rzip/edn (node/coerce '{:deps {}}))
+               (rzip/down)
+               (rzip/right)
+               (u/update-deps CONSIDER_TYPES_RELEASES REPOS)
+               (rzip/root)
+               (node/sexpr))))))


### PR DESCRIPTION
Addresses two bugs in the --update code:

- The presence of "uneval" (#_foo) nodes in a dependency map would cause an
  exception. While rewrite-clj.zip/right skips over whitespace and comments, it
  does not skip over uneval nodes, breaking our assumption that a map always has
  an even amount of children.

- An empty dependency map (e.g. `:deps {}` or `:extra-deps {}`) would cause the
  code to "fall off" the zipper by trying to descend into an empty map. This
  results is `nil`, which in turn caused deps.edn to be overwritten by an empty
  file.

I figured better late than never time to add some tests, so I added test cases
for the affected functions. I also took the liberty to add Kaocha to the project, I hope that's ok.