### PR TITLE
Update README.md suggested one-liner Depot version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Find newer versions of your dependencies in your `deps.edn` file using the [Cloj
 You can try it out easily with this one liner:
 
 ```bash
-$ clojure -Sdeps '{:deps {olical/depot {:mvn/version "1.5.1"}}}' -m depot.outdated.main
+$ clojure -Sdeps '{:deps {olical/depot {:mvn/version "1.5.0"}}}' -m depot.outdated.main
 
 |          Dependency | Current | Latest |
 |---------------------+---------+--------|


### PR DESCRIPTION
The README one-liner uses 1.5.1, which causes the command to throw an exception that the version is not available at the maven repository. This changes the one-liner to 1.5.0, which is the latest clojars version.