### PR TITLE
flag to optionally consider overrides for gather-and-list as well

### DIFF
--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -92,16 +92,19 @@
   [lib coord data]
   (-current-latest-map lib coord data))
 
-(defn gather-outdated [consider-types aliases]
+(defn gather-outdated [consider-types aliases include-overrides]
   (let [deps-map (-> (reader/clojure-env)
                      (:config-files)
                      (reader/read-deps))
         args-map (deps/combine-aliases deps-map aliases)
         overrides (:override-deps args-map)
-        all-deps (merge (:deps deps-map) (:extra-deps args-map))]
+        all-deps (merge (:deps deps-map) (:extra-deps args-map)
+                        (when include-overrides overrides))]
     (->> (for [[lib coord] all-deps
                :let [outdated (current-latest-map lib
-                                                  (get overrides lib coord)
+                                                  (if include-overrides
+                                                    coord
+                                                    (get overrides lib coord))
                                                   {:consider-types consider-types
                                                    :deps-map       deps-map})]]
            (when outdated

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -24,11 +24,12 @@
     :default-desc "release"
     :parse-fn comma-str->keywords-set
     :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
+   ["-o" "--overrides" "Consider overrides for updates instead of pinning to them."]
    ["-u" "--update" "Update deps.edn, or filenames given as additional command line arguments."]
    ["-h" "--help"]])
 
 (defn -main [& args]
-  (let [{{:keys [aliases consider-types help update]} :options
+  (let [{{:keys [aliases consider-types overrides help update]} :options
          files :arguments
          summary :summary} (cli/parse-opts args cli-options)]
     (cond
@@ -44,7 +45,7 @@
         (depot.outdated.update/update-deps-edn! "deps.edn" consider-types))
 
       :else
-      (let [outdated (depot/gather-outdated consider-types aliases)]
+      (let [outdated (depot/gather-outdated consider-types aliases overrides)]
         (if (empty? outdated)
           (println "All up to date!")
           (do (pprint/print-table ["Dependency" "Current" "Latest"] outdated)


### PR DESCRIPTION
It seems like `--update` already processes `override-deps`. This new flag allows for the default gather-and-print action to also consider `override-deps` in a similar fashion.