### PR TITLE
Resolve snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,17 @@ $ clojure -m depot.outdated.main --update ../my-project/deps.edn
 
 ## Freezing snapshots
 
-Maven versions ending in `-SNAPSHOT` are mutable, a maintainer can publish as many snapshots as they like, all with the same version string. This means that re-running the same code twice might yield different results, if in the meanwhile a new snapshot was released.
+Maven has a concept called "virtual" versions, these are similar to Git branches, they are pointers to another version, and the version they point to can change over time. The best known example are snapshot releases. When your `deps.edn` refers to a version `0.4.1-SNAPSHOT`, the version that actually gets installed will look like `0.4.1-20190222.154954-1`.
 
-The `--resolve-snapshots` flag will replace the snapshot version with the current timestamped version that the SNAPSHOT is an alias of, so that your code is once again deterministic.
+A maintainer can publish as many snapshots as they like, all with the same version string. This means that re-running the same code twice might yield different results, if in the meanwhile a new snapshot was released. So installing `0.4.1-SNAPSHOT` again later on may install a completely different version.
+
+For the sake of stability and reproducibility it may be desirable to "lock" this version. This is what the `--resolve-virtual` flag is for. The `--resolve-virtual` flag will replace the snapshot version with the current timestamped version that the SNAPSHOT is an alias of, so that your code is once again deterministic.
+
+Besides `SNAPSHOT` versions `--resolve-virtual` will also handle the special version strings `"RELEASE"` and `"LATEST"`
+
 
 ```
-% clojure -Sdeps '{:deps {olical/depot {:local/root "/home/arne/github/depot"}}}' -m depot.outdated.main --resolve-snapshots
+% clojure -Sdeps '{:deps {olical/depot {:local/root "/home/arne/github/depot"}}}' -m depot.outdated.main --resolve-virtual
 Resolving: deps.edn
    cider/piggieback 0.4.1-SNAPSHOT --> 0.4.1-20190222.154954-1
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can try it out easily with this one liner:
 $ clojure -Sdeps '{:deps {olical/depot {:mvn/version "1.7.0"}}}' -m depot.outdated.main
 
 |          Dependency | Current | Latest |
-|---------------------+---------+--------|
+|---------------------|---------|--------|
 | org.clojure/clojure |   1.8.0 |  1.9.0 |
 ```
 
@@ -28,7 +28,7 @@ I'd recommend adding depot as an alias in your own `deps.edn` file, this will al
 $ clojure -Aoutdated -a outdated
 
 |   Dependency | Current | Latest |
-|--------------+---------+--------|
+|--------------|---------|--------|
 | olical/depot |   ..... |  ..... |
 ```
 
@@ -66,6 +66,18 @@ can instead pass one or more filenames in explicitly.
 
 ``` bash
 $ clojure -m depot.outdated.main --update ../my-project/deps.edn
+```
+
+## Freezing snapshots
+
+Maven versions ending in `-SNAPSHOT` are mutable, a maintainer can publish as many snapshots as they like, all with the same version string. This means that re-running the same code twice might yield different results, if in the meanwhile a new snapshot was released.
+
+The `--resolve-snapshots` flag will replace the snapshot version with the current timestamped version that the SNAPSHOT is an alias of, so that your code is once again deterministic.
+
+```
+% clojure -Sdeps '{:deps {olical/depot {:local/root "/home/arne/github/depot"}}}' -m depot.outdated.main --resolve-snapshots
+Resolving: deps.edn
+   cider/piggieback 0.4.1-SNAPSHOT --> 0.4.1-20190222.154954-1
 ```
 
 ## Existing work

--- a/deps.edn
+++ b/deps.edn
@@ -9,5 +9,5 @@
                  :main-opts ["-m" "depot.dev.cider"]}
            :test {:extra-deps {clj-time {:mvn/version "0.14.4"}
                                olical/cljs-test-runner {:git/url "https://github.com/Olical/cljs-test-runner.git"
-                                                        :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}
-                               lambdaisland/kaocha {:mvn/version "0.0-266"}}}}}
+                                                        :sha "23770db50bf55c98f2907b9e95f4f88b9e316e61"}
+                               lambdaisland/kaocha {:mvn/version "0.0-389"}}}}}

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -22,7 +22,7 @@
       (integer? type) :release
       :else :unrecognised)))
 
-(defn- make-session
+(defn make-session
   ^RepositorySystemSession [^RepositorySystem system local-repo]
   (let [session (MavenRepositorySystemUtils/newSession)
         local-repo-mgr (.newLocalRepositoryManager system session (maven/make-local-repo local-repo))]

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -4,7 +4,8 @@
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [depot.outdated :as depot]
-            [depot.outdated.update]))
+            [depot.outdated.update]
+            [depot.outdated.resolve-snapshots]))
 
 (defn comma-str->keywords-set [comma-str]
   (into #{} (map keyword) (str/split comma-str #",")))
@@ -26,10 +27,11 @@
     :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
    ["-o" "--overrides" "Consider overrides for updates instead of pinning to them."]
    ["-u" "--update" "Update deps.edn, or filenames given as additional command line arguments."]
+   ["-r" "--resolve-snapshots" "Convert -SNAPSHOT versions into immutable timestamped versions."]
    ["-h" "--help"]])
 
 (defn -main [& args]
-  (let [{{:keys [aliases consider-types overrides help update]} :options
+  (let [{{:keys [aliases consider-types overrides help update resolve-snapshots]} :options
          files :arguments
          summary :summary} (cli/parse-opts args cli-options)]
     (cond
@@ -43,6 +45,12 @@
         (run! #(depot.outdated.update/update-deps-edn! % consider-types)
               files)
         (depot.outdated.update/update-deps-edn! "deps.edn" consider-types))
+
+
+      resolve-snapshots
+      (if (seq files)
+        (run! depot.outdated.resolve-snapshots/update-deps-edn! files)
+        (depot.outdated.resolve-snapshots/update-deps-edn! "deps.edn"))
 
       :else
       (let [outdated (depot/gather-outdated consider-types aliases overrides)]

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -5,7 +5,7 @@
             [clojure.tools.cli :as cli]
             [depot.outdated :as depot]
             [depot.outdated.update]
-            [depot.outdated.resolve-snapshots]))
+            [depot.outdated.resolve-virtual]))
 
 (defn comma-str->keywords-set [comma-str]
   (into #{} (map keyword) (str/split comma-str #",")))
@@ -27,11 +27,11 @@
     :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
    ["-o" "--overrides" "Consider overrides for updates instead of pinning to them."]
    ["-u" "--update" "Update deps.edn, or filenames given as additional command line arguments."]
-   ["-r" "--resolve-snapshots" "Convert -SNAPSHOT versions into immutable timestamped versions."]
+   ["-r" "--resolve-virtual" "Convert -SNAPSHOT/RELEASE/LATEST versions into immutable references."]
    ["-h" "--help"]])
 
 (defn -main [& args]
-  (let [{{:keys [aliases consider-types overrides help update resolve-snapshots]} :options
+  (let [{{:keys [aliases consider-types overrides help update resolve-virtual]} :options
          files :arguments
          summary :summary} (cli/parse-opts args cli-options)]
     (cond
@@ -47,10 +47,10 @@
         (depot.outdated.update/update-deps-edn! "deps.edn" consider-types))
 
 
-      resolve-snapshots
+      resolve-virtual
       (if (seq files)
-        (run! depot.outdated.resolve-snapshots/update-deps-edn! files)
-        (depot.outdated.resolve-snapshots/update-deps-edn! "deps.edn"))
+        (run! depot.outdated.resolve-virtual/update-deps-edn! files)
+        (depot.outdated.resolve-virtual/update-deps-edn! "deps.edn"))
 
       :else
       (let [outdated (depot/gather-outdated consider-types aliases overrides)]

--- a/src/depot/outdated/resolve_snapshots.clj
+++ b/src/depot/outdated/resolve_snapshots.clj
@@ -1,0 +1,45 @@
+(ns depot.outdated.resolve-snapshots
+  (:require [clojure.tools.deps.alpha.reader :as reader]
+            [depot.zip :as dzip]
+            [depot.outdated :as outdated]
+            [rewrite-clj.zip :as rzip]
+            [clojure.zip :as zip]
+            [clojure.tools.deps.alpha.util.maven :as maven]
+            [clojure.string :as str]))
+
+(defn resolve-version [lib coord repos]
+  (let [artifact     (maven/coord->artifact lib coord)
+        system       (maven/make-system)
+        session      (outdated/make-session system maven/default-local-repo)
+        remote-repos (mapv maven/remote-repo repos)
+        request      (org.eclipse.aether.resolution.VersionRequest. artifact remote-repos nil)]
+    (.getVersion (.resolveVersion system session request))))
+
+(defn resolve-all
+  [loc repos]
+  (dzip/transform-coords
+   loc
+   (fn [[artifact coords]]
+     (if (some-> coords :mvn/version (str/ends-with? "-SNAPSHOT"))
+       (let [version (resolve-version artifact coords repos)]
+         (println "   " artifact (:mvn/version coords) "-->" version)
+         (assoc coords :mvn/version version))
+       coords))))
+
+(defn update-deps-edn! [file]
+  (println "Resolving:" file)
+  (let [deps     (-> (reader/clojure-env) :config-files reader/read-deps)
+        loc      (rzip/of-file file)
+        old-deps (slurp file)
+        loc'     (resolve-all loc (:mvn/repos deps))
+        new-deps (rzip/root-string loc')]
+    (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
+      (if (= old-deps new-deps)
+        (println "  All up to date!")
+        (try
+          (spit file new-deps)
+          (catch java.io.FileNotFoundException e
+            (println "  [ERROR] Permission denied: " file)))))))
+
+#_
+(resolve-version 'cider/piggieback {:mvn/version "0.4.1-SNAPSHOT"} maven/standard-repos)

--- a/src/depot/zip.clj
+++ b/src/depot/zip.clj
@@ -48,3 +48,54 @@
       (if-let [v (f loc)]
         (recur (right (right v)) (rzip/up v))
         (recur (right (right loc)) parent)))))
+
+;; TODO make sure this only matches map keys
+(defn lib?
+  "Is the loc at a library name."
+  [loc]
+  (and (= :token (rzip/tag loc))
+       (rzip/map? (rzip/up loc))
+       (#{:deps :extra-deps :override-deps} (some-> loc
+                                                    rzip/up
+                                                    rzip/left
+                                                    rzip/sexpr))))
+
+(defn next-lib
+  "Find the next loc, depth first, that is a library name."
+  [loc]
+  (rzip/find-next-depth-first loc lib?))
+
+(defn lib-loc-seq
+  "A sequence of zippers each pointing at a library name."
+  [loc]
+  (->> loc
+       next-lib
+       (iterate next-lib)
+       (take-while identity)))
+
+(defn loc->lib
+  "Given a zipper pointing at a library name, return a pair of [name
+  coordinate-map]"
+  [loc]
+  [(rzip/sexpr loc)
+   (rzip/sexpr (rzip/right loc))])
+
+(defn lib-seq
+  "A sequence of all libraries in the given zipper over deps.edn, returning a seq
+  of [name, coordinate-map] pairs."
+  [loc]
+  (map loc->lib (lib-loc-seq loc)))
+
+(defn transform-coords
+  "Transform all coordinate maps in the given zipper over deps.edn. The function f
+  takes a pair of [library-name coordinate-map] and returns a coordinate map."
+  [loc f & args]
+  (loop [loc loc
+         loc' (next-lib loc)]
+    (if loc'
+      (let [coords (apply f (loc->lib loc') args)
+            loc (-> loc'
+                    (rzip/right)
+                    (rzip/replace coords))]
+        (recur loc (next-lib loc)))
+      loc)))

--- a/src/depot/zip.clj
+++ b/src/depot/zip.clj
@@ -1,0 +1,50 @@
+(ns depot.zip
+  "Extra zipper helpers."
+  (:require [rewrite-clj.zip :as rzip]
+            [clojure.zip :as zip]))
+
+(defn- zip-skip-ws
+  "Skip whitespace, comments, and uneval nodes."
+  [loc]
+  (loop [loc loc]
+    (if (and loc
+             (not (rzip/end? loc))
+             (#{:comment :whitespace :newline :comma :uneval} (rzip/tag loc)))
+      (recur (zip/right loc))
+      loc)))
+
+(defn right
+  "Like [[rewrite-clj.zip/right]], but also skip over uneval nodes"
+  [loc]
+  (some-> loc rzip/right zip-skip-ws))
+
+(defn zget
+  "Like [[clojure.core/get]], but for a zipper over a map.
+
+  Takes and returns a zipper (loc)."
+  [loc key]
+  (rzip/right
+   (rzip/find-value (rzip/down loc) (comp right right) key)))
+
+(defn map-vals
+  "Like [[rewrite-clj.zip/map-vals]], but account for uneval nodes, and can take extra args."
+  [f loc & args]
+  (let [loc' (rzip/down loc)]
+    (if loc'
+      (loop [keyloc loc']
+        (let [valloc (apply f (right keyloc) args)]
+          (if-let [next-keyloc (right valloc)]
+            (recur next-keyloc)
+            (rzip/up valloc))))
+      loc)))
+
+(defn map-keys
+  "Like [[rewrite-clj.zip/map-keys]], but account for uneval nodes."
+  [f zloc]
+  (loop [loc (rzip/down zloc)
+         parent zloc]
+    (if-not (and loc (rzip/node loc))
+      parent
+      (if-let [v (f loc)]
+        (recur (right (right v)) (rzip/up v))
+        (recur (right (right loc)) parent)))))

--- a/src/depot/zip.clj
+++ b/src/depot/zip.clj
@@ -5,13 +5,20 @@
 
 (defn- zip-skip-ws
   "Skip whitespace, comments, and uneval nodes."
+  ([loc]
+   (zip-skip-ws loc rzip/right rzip/end?))
+  ([loc next end?]
+   (loop [loc loc]
+     (if (and loc
+              (not (rzip/end? loc))
+              (#{:comment :whitespace :newline :comma :uneval} (rzip/tag loc)))
+       (recur (zip/right loc))
+       loc))))
+
+(defn left
+  "Like [[rewrite-clj.zip/left], but also skip over uneval nodes"
   [loc]
-  (loop [loc loc]
-    (if (and loc
-             (not (rzip/end? loc))
-             (#{:comment :whitespace :newline :comma :uneval} (rzip/tag loc)))
-      (recur (zip/right loc))
-      loc)))
+  (some-> loc rzip/left (zip-skip-ws rzip/left rzip/leftmost?)))
 
 (defn right
   "Like [[rewrite-clj.zip/right]], but also skip over uneval nodes"
@@ -23,8 +30,42 @@
 
   Takes and returns a zipper (loc)."
   [loc key]
-  (rzip/right
+  {:pre [(rzip/map? loc)]}
+  (right
    (rzip/find-value (rzip/down loc) (comp right right) key)))
+
+(defn zassoc
+  "Like [[clojure.core/assoc]], but for a zipper over a map.
+
+  New keys will be added at the end, preserving indentation."
+  [loc k v]
+  {:pre [(rzip/map? loc)]}
+  (if-let [vloc (zget loc k)]
+    ;; key found, just replace the value
+    (rzip/up (rzip/replace vloc v))
+
+    ;; key not found, add it to the end of the map
+    (let [;; loc to the last value in the map
+          loc (rzip/rightmost (rzip/down loc))
+          ;; whitespace nodes preceding the last key in the map. This way we
+          ;; maintain the same use of commas, newlines, whitespace
+          ws-nodes (->> loc
+                        left
+                        zip/lefts
+                        reverse
+                        (take-while rewrite-clj.node/whitespace?)
+                        reverse)
+          ;; copy the whitespace nodes into the end of the map
+          loc (reduce (fn [loc node]
+                        (zip/right (zip/insert-right loc node)))
+                      loc
+                      ws-nodes)]
+      ;; insert key and value
+      (-> loc
+          (rzip/insert-right k)
+          (rzip/right)
+          (rzip/insert-right v)
+          (rzip/up)))))
 
 (defn map-vals
   "Like [[rewrite-clj.zip/map-vals]], but account for uneval nodes, and can take extra args."
@@ -53,11 +94,12 @@
 (defn lib?
   "Is the loc at a library name."
   [loc]
-  (and (= :token (rzip/tag loc))
+  (and loc
+       (= :token (rzip/tag loc))
        (rzip/map? (rzip/up loc))
        (#{:deps :extra-deps :override-deps} (some-> loc
                                                     rzip/up
-                                                    rzip/left
+                                                    left
                                                     rzip/sexpr))))
 
 (defn next-lib
@@ -78,7 +120,7 @@
   coordinate-map]"
   [loc]
   [(rzip/sexpr loc)
-   (rzip/sexpr (rzip/right loc))])
+   (rzip/sexpr (right loc))])
 
 (defn lib-seq
   "A sequence of all libraries in the given zipper over deps.edn, returning a seq
@@ -86,16 +128,13 @@
   [loc]
   (map loc->lib (lib-loc-seq loc)))
 
-(defn transform-coords
+(defn transform-libs
   "Transform all coordinate maps in the given zipper over deps.edn. The function f
-  takes a pair of [library-name coordinate-map] and returns a coordinate map."
+  takes a loc pointing at the library name, and returns a new loc."
   [loc f & args]
   (loop [loc loc
          loc' (next-lib loc)]
     (if loc'
-      (let [coords (apply f (loc->lib loc') args)
-            loc (-> loc'
-                    (rzip/right)
-                    (rzip/replace coords))]
+      (let [loc (-> (apply f loc' args) (rzip/next))]
         (recur loc (next-lib loc)))
       loc)))

--- a/test/depot/outdated/resolve_virtual_test.clj
+++ b/test/depot/outdated/resolve_virtual_test.clj
@@ -1,0 +1,19 @@
+(ns depot.outdated.resolve-virtual-test
+  (:require [depot.outdated.resolve-virtual :as r]
+            [clojure.test :refer :all]
+            [rewrite-clj.zip :as rzip]
+            [clojure.tools.deps.alpha.util.maven :as maven]))
+
+(deftest resolve-all-test
+  (is (= '{:deps
+           {org.clojure/clojure {:mvn/version "1.10.0"},
+            cider/piggieback    {:mvn/version "0.4.1-20190222.154954-1"}}}
+         (with-redefs [r/resolve-version (fn [lib _ _]
+                                           ('{org.clojure/clojure "1.10.0"
+                                              cider/piggieback    "0.4.1-20190222.154954-1"} lib))]
+           (-> "{:deps {org.clojure/clojure {:mvn/version \"LATEST\"}
+cider/piggieback {:mvn/version \"0.4.1-SNAPSHOT\"}}}"
+               rzip/of-string
+               (r/resolve-all maven/standard-repos)
+               rzip/root
+               rewrite-clj.node.protocols/sexpr)))))

--- a/test/depot/outdated/update_test.clj
+++ b/test/depot/outdated/update_test.clj
@@ -2,35 +2,12 @@
   (:require [clojure.test :refer :all]
             [depot.outdated.update :as u]
             [rewrite-clj.node :as node]
-            [rewrite-clj.zip :as rzip]))
+            [rewrite-clj.zip :as rzip]
+            [clojure.tools.deps.alpha.util.maven :as maven]))
 
 (def CONSIDER_TYPES_RELEASES #{:release})
-(def REPOS {:mvn/repos
-            {"central" {:url "https://repo1.maven.org/maven2/"},
-             "clojars" {:url "https://repo.clojars.org/"}}})
 
-(deftest zip-skip-ws-test
-  (is (= :foo
-         (-> (rzip/of-string "   ,,, ;;;\n#_123 :foo")
-             (u/zip-skip-ws)
-             rzip/sexpr))))
-
-(deftest zget-test
-  (is (= :bar
-         (-> (rzip/edn (node/coerce {:foo :bar
-                                     :bar :baz}))
-             (u/zget :foo)
-             (rzip/sexpr))))
-
-  (is (nil?
-       (-> (rzip/edn (node/coerce {:foo :bar
-                                   :bar :baz}))
-           (u/zget :unkown))))
-
-  (is (= :baz
-         (-> (rzip/of-string "{:foo :bar #_uneval :bar :baz}")
-             (u/zget :bar)
-             (rzip/sexpr)))))
+(def REPOS {:mvn/repos maven/standard-repos})
 
 (deftest update-loc?-test
   (testing "don't update when tagged with :depot/ignore"

--- a/test/depot/zip_test.clj
+++ b/test/depot/zip_test.clj
@@ -26,3 +26,20 @@
          (-> (rzip/of-string "{:foo :bar #_uneval :bar :baz}")
              (u/zget :bar)
              (rzip/sexpr)))))
+
+(deftest zassoc-test
+  (let [loc (rzip/of-string "{:foo :bar,\n :baz :baq}")]
+    (is (= "{:foo 123,\n :baz :baq}"
+           (-> loc
+               (u/zassoc :foo 123)
+               rzip/root-string)))
+
+    (is (= "{:foo :bar,\n :baz 123}"
+           (-> loc
+               (u/zassoc :baz 123)
+               rzip/root-string)))
+
+    (is (= "{:foo :bar,\n :baz :baq,\n :baq 123}"
+           (-> loc
+               (u/zassoc :baq 123)
+               rzip/root-string)))))

--- a/test/depot/zip_test.clj
+++ b/test/depot/zip_test.clj
@@ -1,0 +1,28 @@
+(ns depot.zip-test
+  (:require [depot.zip :as u]
+            [rewrite-clj.zip :as rzip]
+            [rewrite-clj.node :as node]
+            [clojure.test :refer :all]))
+
+(deftest zip-skip-ws-test
+  (is (= :foo
+         (-> (rzip/of-string "   ,,, ;;;\n#_123 :foo")
+             (#'u/zip-skip-ws)
+             rzip/sexpr))))
+
+(deftest zget-test
+  (is (= :bar
+         (-> (rzip/edn (node/coerce {:foo :bar
+                                     :bar :baz}))
+             (u/zget :foo)
+             (rzip/sexpr))))
+
+  (is (nil?
+       (-> (rzip/edn (node/coerce {:foo :bar
+                                   :bar :baz}))
+           (u/zget :unkown))))
+
+  (is (= :baz
+         (-> (rzip/of-string "{:foo :bar #_uneval :bar :baz}")
+             (u/zget :bar)
+             (rzip/sexpr)))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,2 @@
+#kaocha/v1
+{:plugins [:kaocha.plugin/notifier]}


### PR DESCRIPTION
This still has some issues, do not merge (yet).

Adds an extra flag to freeze/resolve snapshot versions, so they get replaced with immutable references.

I started by refactoring the update code, pulling all zipper related stuff into its own namespace, and adding some more high level functions, e.g. `(transform-coords loc f)` lets you update all coordinate maps by applying a function over them. This simplified the update code quite a bit, and made implementing the new functionality much easier.
 
It also has the benefit that now all version lookups are parallelized in one go, before each `:deps`/`:override-deps`/`:extra-deps`/`:aliases` was still handled separately, one at a time.

This does break some existing behavior which I still need to fix

- [x] formatting in coordinate maps is not preserved
- [x] `^:depot/ignore` currently only works on the artifact symbol, not on the coords map or any of the parents

Still it's already quite useful, to try it out

```
clj -Sdeps '{:deps {olical/depot {:git/url "https://github.com/plexus/depot.git" :sha "706532e554daf038bc17c173e5db40ba075d11c3"}}}' -m depot.outdated.main --resolve-snapshots
```
