### PR TITLE
Better deal with uneval nodes

### DIFF
--- a/test/depot/outdated/resolve_virtual_test.clj
+++ b/test/depot/outdated/resolve_virtual_test.clj
@@ -3,7 +3,8 @@
             [clojure.test :refer :all]
             [rewrite-clj.zip :as rzip]
             [clojure.tools.deps.alpha.util.maven :as maven]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [depot.zip :as dzip]))
 
 (deftest resolve-all-test
   (is (= '{:deps

--- a/test/depot/zip_test.clj
+++ b/test/depot/zip_test.clj
@@ -4,12 +4,6 @@
             [rewrite-clj.node :as node]
             [clojure.test :refer :all]))
 
-(deftest zip-skip-ws-test
-  (is (= :foo
-         (-> (rzip/of-string "   ,,, ;;;\n#_123 :foo")
-             (#'u/zip-skip-ws)
-             rzip/sexpr))))
-
 (deftest right-test
   (is (= :y
          (-> (rzip/of-string "[:x   ,,#_123\n  :y]")


### PR DESCRIPTION
We now have our own versions of left/right/next that all correctly jump over
uneval nodes, in particular we want to avoid descending into uneval subtrees (as
they may contain gibberish), or call sexp on an uneval node (as that will
outright fail).

See https://github.com/xsc/rewrite-clj/issues/70

Closes #20 