### PR TITLE
replace calls to clojure-env with new api

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure {:mvn/version "1.10.0"}
-  org.clojure/tools.deps.alpha {:mvn/version "0.6.496"}
+  org.clojure/tools.deps.alpha {:mvn/version "0.7.516"}
   org.clojure/tools.cli {:mvn/version "0.4.1"}
   rewrite-clj {:mvn/version "0.6.1"}
   version-clj {:mvn/version "0.1.2"}}

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -102,8 +102,7 @@
   (-current-latest-map lib coord data))
 
 (defn gather-outdated [consider-types aliases include-overrides]
-  (let [deps-map (-> (reader/clojure-env)
-                     (:config-files)
+  (let [deps-map (-> (reader/default-deps)
                      (reader/read-deps))
         args-map (deps/combine-aliases deps-map aliases)
         overrides (:override-deps args-map)

--- a/src/depot/outdated/resolve_virtual.clj
+++ b/src/depot/outdated/resolve_virtual.clj
@@ -33,7 +33,7 @@
 
 (defn update-deps-edn! [file]
   (println "Resolving:" file)
-  (let [deps     (-> (reader/clojure-env) :config-files reader/read-deps)
+  (let [deps     (-> (reader/default-deps) reader/read-deps)
         loc      (rzip/of-file file)
         old-deps (slurp file)
         loc'     (resolve-all loc (:mvn/repos deps))

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -79,8 +79,7 @@
   `consider-types` is a set, one of [[depot.outdated/version-types]]. "
   [file consider-types]
   (println "Updating:" file)
-  (let [deps (-> (reader/clojure-env)
-                 :config-files
+  (let [deps (-> (reader/default-deps)
                  reader/read-deps)
 
         repos    (select-keys deps [:mvn/repos :mvn/local-repo])


### PR DESCRIPTION
clojure-env has been deprecated and will be removed. The latest version of tools.deps.alpha has a new method `reader/default-deps`  that can return the set of deps.edn config files that replicates the logic from clj without shelling out.