### PR TITLE
Unification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Depot changes
 
+## Unreleased
+
+* **Breaking** Replaced the `--update` flag with the `--write` flag.
+* **Breaking** Replace support for :mvn/local-repo with :depot/local-maven-repo
+* **Breaking** Changed scoping rules to be the same with or without the `--write` flag
+* **Breaking** Changed scoping rules to be the same with or without the `--resolve-virtual` flag
+* **Breaking** Changed `--resolve-virtual` to be read-only unless combined with `--write`
+* Fixed inconsistent output styles
+* Added the `--every` flag which allows checking all aliases at once
+
 ## v1.8.4
 
  * Republish v1.8.3 without the `target` directory which contained some old AOTed classes. Thanks for the heads up, Sean Corfield!

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * **Breaking** Replaced the `--update` flag with the `--write` flag.
 * **Breaking** Changed scoping rules to be the same with or without the `--write` flag
+* **Breaking** Remove support for the `--overrides` flag. `:override-deps` will be checked by default.
+  To ignore them, use the `:depot/ignore` metadata.
 * **Breaking** Changed scoping rules to be the same with or without the `--resolve-virtual` flag
 * **Breaking** Changed `--resolve-virtual` to be read-only unless combined with `--write`
 * Fixed inconsistent output styles

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 * **Breaking** Replaced the `--update` flag with the `--write` flag.
-* **Breaking** Replace support for :mvn/local-repo with :depot/local-maven-repo
 * **Breaking** Changed scoping rules to be the same with or without the `--write` flag
 * **Breaking** Changed scoping rules to be the same with or without the `--resolve-virtual` flag
 * **Breaking** Changed `--resolve-virtual` to be read-only unless combined with `--write`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ clojure -Aoutdated ../my-project/deps.edn
 By default, only dependencies under the top-level `:deps` are considered.
 
 To also consider `:extra-deps` and `:override-deps` under aliases, see
-the the `--aliases`, `--every`, and `--overrides` flags.
+the the `--aliases` and `--every` flags.
 
 To prevent Depot from touching certain parts of your `deps.edn`, mark
 them with the `^:depot/ignore` metadata.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ You can try it out easily with this one liner:
 
 ```bash
 $ clojure -Sdeps '{:deps {olical/depot {:mvn/version "1.8.4"}}}' -m depot.outdated.main
-
-|          Dependency | Current | Latest |
-|---------------------|---------|--------|
-| org.clojure/clojure |   1.9.0 | 1.10.0 |
+Checking for old versions in: deps.edn
+  org.clojure/clojure {:mvn/version "1.9.0"} -> {:mvn/version "1.10.0"}
 ```
 
 I'd recommend adding depot as an alias in your own `deps.edn` file, this will allow it to check itself for updates:
@@ -25,30 +23,29 @@ I'd recommend adding depot as an alias in your own `deps.edn` file, this will al
 ```
 
 ```bash
-$ clojure -Aoutdated -a outdated
-
-|   Dependency | Current | Latest |
-|--------------|---------|--------|
-| olical/depot |   ..... |  ..... |
+$ clojure -Aoutdated --aliases outdated
+Checking for old versions in: deps.edn
+  olical/depot {:mvn/version "..."} -> {:mvn/version "..."}
 ```
 
-### Updating `deps.edn`
+### Controlling which files are checked
 
-To automatically update the versions in `deps.edn`, use `--update`.
+By default Depot looks for `deps.edn` in the current working directory. You
+can instead pass one or more filenames in explicitly.
 
-```bash
-$ clojure -m depot.outdated.main --update
-Updating: deps.edn
-  rewrite-clj {:mvn/version "0.6.0"} -> {:mvn/version "0.6.1"}
-  cider/cider-nrepl {:mvn/version "0.17.0"} -> {:mvn/version "0.18.0"}
-  clj-time {:mvn/version "0.14.4"} -> {:mvn/version "0.15.1"}
-  olical/cljs-test-runner {:sha "5a18d41648d5c3a64632b5fec07734d32cca7671"} -> {:sha "da9710b389782d4637ef114176f6e741225e16f0"}
+``` bash
+$ clojure -Aoutdated ../my-project/deps.edn
 ```
 
-This will leave any formatting, whitespace, and comments intact. It will update
-both the top level deps and any `:aliases` / `:extra-deps`. To prevent Depot
-from touching certain parts of your `deps.edn`, mark them with the
-`^:depot/ignore` metadata.
+### Controlling which part of the file are checked
+
+By default, only dependencies under the top-level `:deps` are considered.
+
+To also consider `:extra-deps` and `:override-deps` under aliases, see
+the the `--aliases`, `--every`, and `--overrides` flags.
+
+To prevent Depot from touching certain parts of your `deps.edn`, mark
+them with the `^:depot/ignore` metadata.
 
 ``` clojure
 {:deps {...}
@@ -61,27 +58,39 @@ from touching certain parts of your `deps.edn`, mark them with the
                                {org.clojure/clojure {:mvn/version "1.9.0"}}}}}
 ```
 
-`--update` by default looks for `deps.edn` in the current working directory. You
-can instead pass one or more filenames in explicitly.
+The metadata can be placed on the artifact name, the coord map or on
+any map containing the dependency in question.
 
-``` bash
-$ clojure -m depot.outdated.main --update ../my-project/deps.edn
+### Updating `deps.edn`
+
+By default, depot only prints the new versions. To update the file in
+place, include the `--write` flag. This will leave any formatting,
+whitespace, and comments intact.
+
+```bash
+$ clojure -Aoutdated --write
+Updating old versions in: deps.edn
+  rewrite-clj {:mvn/version "0.6.0"} -> {:mvn/version "0.6.1"}
+  cider/cider-nrepl {:mvn/version "0.17.0"} -> {:mvn/version "0.18.0"}
+  clj-time {:mvn/version "0.14.4"} -> {:mvn/version "0.15.1"}
+  olical/cljs-test-runner {:sha "5a18d41648d5c3a64632b5fec07734d32cca7671"} -> {:sha "da9710b389782d4637ef114176f6e741225e16f0"}
 ```
 
-## Freezing snapshots
+
+### Freezing snapshots
 
 Maven has a concept called "virtual" versions, these are similar to Git branches, they are pointers to another version, and the version they point to can change over time. The best known example are snapshot releases. When your `deps.edn` refers to a version `0.4.1-SNAPSHOT`, the version that actually gets installed will look like `0.4.1-20190222.154954-1`.
 
 A maintainer can publish as many snapshots as they like, all with the same version string. This means that re-running the same code twice might yield different results, if in the meanwhile a new snapshot was released. So installing `0.4.1-SNAPSHOT` again later on may install a completely different version.
 
-For the sake of stability and reproducibility it may be desirable to "lock" this version. This is what the `--resolve-virtual` flag is for. The `--resolve-virtual` flag will replace the snapshot version with the current timestamped version that the SNAPSHOT is an alias of, so that your code is once again deterministic.
+For the sake of stability and reproducibility it may be desirable to "lock" this version. This is what the `--resolve-virtual` flag is for. The `--resolve-virtual` flag will resolve the virtual version to the current timestamped version that the SNAPSHOT is an alias of, so that your code is once again deterministic.
 
 Besides `SNAPSHOT` versions `--resolve-virtual` will also handle the special version strings `"RELEASE"` and `"LATEST"`
 
 ```
-% clojure -Sdeps '{:deps {olical/depot {:local/root "/home/arne/github/depot"}}}' -m depot.outdated.main --resolve-virtual
-Resolving: deps.edn
-   cider/piggieback 0.4.1-SNAPSHOT --> 0.4.1-20190222.154954-1
+% clojure -Aoutdated --resolve-virtual
+Checking virtual versions in: deps.edn
+   cider/piggieback {:mvn/version "0.4.1-SNAPSHOT"} -> {:mvn/version "0.4.1-20190222.154954-1"}
 ```
 
 ## Existing work

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -100,22 +100,3 @@
   newer version otherwise returns `nil`."
   [lib coord config]
   (-current-latest-map lib coord config))
-
-(defn gather-outdated [consider-types aliases include-overrides]
-  (let [deps-map (-> (reader/default-deps)
-                     (reader/read-deps))
-        args-map (deps/combine-aliases deps-map aliases)
-        overrides (:override-deps args-map)
-        all-deps (merge (:deps deps-map) (:extra-deps args-map)
-                        (when include-overrides overrides))]
-    (->> (pmap (fn [[lib coord]]
-                 (let [outdated (current-latest-map lib
-                                                    (if include-overrides
-                                                      coord
-                                                      (get overrides lib coord))
-                                                    {:consider-types consider-types
-                                                     :deps-map       deps-map})]
-                   (when outdated
-                     (assoc outdated "Dependency" lib)))) all-deps)
-         (keep identity)
-         (sort-by #(get % "Dependency")))))

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -29,8 +29,8 @@
     (.setLocalRepositoryManager session local-repo-mgr)
     session))
 
-(defn coord->version-status [lib coord {:keys [mvn/repos depot/local-maven-repo]}]
-  (let [local-repo (or local-maven-repo maven/default-local-repo)
+(defn coord->version-status [lib coord {:keys [mvn/repos mvn/local-repo]}]
+  (let [local-repo (or local-repo maven/default-local-repo)
         remote-repos (mapv maven/remote-repo repos)
         system (maven/make-system)
         session (make-session system local-repo)

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -29,8 +29,8 @@
     (.setLocalRepositoryManager session local-repo-mgr)
     session))
 
-(defn coord->version-status [lib coord {:keys [mvn/repos mvn/local-repo]}]
-  (let [local-repo (or local-repo maven/default-local-repo)
+(defn coord->version-status [lib coord {:keys [mvn/repos depot/local-maven-repo]}]
+  (let [local-repo (or local-maven-repo maven/default-local-repo)
         remote-repos (mapv maven/remote-repo repos)
         system (maven/make-system)
         session (make-session system local-repo)

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -1,9 +1,8 @@
 (ns depot.outdated
   (:require [clojure.java.shell :as sh]
             [clojure.string :as str]
-            [clojure.tools.deps.alpha :as deps]
+            [clojure.tools.deps.alpha] ;; need for multimethods
             [clojure.tools.deps.alpha.extensions :as ext]
-            [clojure.tools.deps.alpha.reader :as reader]
             [clojure.tools.deps.alpha.util.maven :as maven]
             [version-clj.core :as version])
   (:import org.apache.maven.repository.internal.MavenRepositorySystemUtils

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -59,8 +59,8 @@
   nil)
 
 (defmethod -current-latest-map :mvn
-  [lib coord {:keys [deps-map consider-types]}]
-  (let [{:keys [types selected]} (coord->version-status lib coord deps-map)
+  [lib coord {:keys [consider-types] :as config}]
+  (let [{:keys [types selected]} (coord->version-status lib coord config)
         latest                   (find-latest types consider-types)]
     (when (and (not (str/blank? selected))
                (not (str/blank? latest))
@@ -98,8 +98,8 @@
 (defn current-latest-map
   "Returns a map containing `'Current'` and `'Latest'` if the dependency has a
   newer version otherwise returns `nil`."
-  [lib coord data]
-  (-current-latest-map lib coord data))
+  [lib coord config]
+  (-current-latest-map lib coord config))
 
 (defn gather-outdated [consider-types aliases include-overrides]
   (let [deps-map (-> (reader/default-deps)

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -65,8 +65,8 @@
     (when (and (not (str/blank? selected))
                (not (str/blank? latest))
                (= (version/version-compare latest selected) 1))
-      {"Current" selected
-       "Latest"  latest})))
+      {:current selected
+       :latest  latest})))
 
 (defn- parse-git-ls-remote
   "Returns a map of ref name to the latest sha for that ref name."
@@ -92,11 +92,11 @@
     (when (and (= exit 0)
                (neg? (ext/compare-versions
                        lib coord (assoc coord :sha latest-remote-sha) {})))
-      {"Current" (:sha coord)
-       "Latest"  latest-remote-sha})))
+      {:current (:sha coord)
+       :latest  latest-remote-sha})))
 
 (defn current-latest-map
-  "Returns a map containing `'Current'` and `'Latest'` if the dependency has a
+  "Returns a map containing `:current` and `:latest` if the dependency has a
   newer version otherwise returns `nil`."
   [lib coord config]
   (-current-latest-map lib coord config))
@@ -116,7 +116,7 @@
            new-version (-> (current-latest-map artifact
                                                      coords
                                                      config)
-                           (get "Latest"))]
+                           (get :latest))]
        (when (and old-version
                   ;; ignore these Maven 2 legacy identifiers
                   (not (#{"RELEASE" "LATEST"} old-version))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -1,6 +1,5 @@
 (ns depot.outdated.main
-  (:require [clojure.pprint :as pprint]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [depot.outdated :as depot]

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -49,19 +49,19 @@
         (println " If no files are given, defaults to using \"deps.edn\".\n")
         (println summary))
 
-      resolve-virtual
-      (if (seq files)
-        (run! resolve-virtual/update-deps-edn! files)
-        (resolve-virtual/update-deps-edn! "deps.edn"))
-
       :else
       (let [files (if (seq files) files ["deps.edn"])
             overrides (or (when every true) overrides)
             check-alias? (if every (constantly true) (set aliases))
-            messages (:update-old messages)]
+            messages (if resolve-virtual
+                       (:resolve-virtual messages)
+                       (:update-old messages))
+            new-versions (if resolve-virtual
+                           resolve-virtual/pinned-versions
+                           update/new-versions)]
         (when (and every aliases)
           (println "--every and --aliases are mutually exclusive.")
           (System/exit 1))
-        (run! #(update/apply-new-versions % consider-types check-alias? overrides write messages)
+        (run! #(update/apply-new-versions % consider-types check-alias? overrides write messages new-versions)
               files)))
     (shutdown-agents)))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -41,19 +41,13 @@
         (println "USAGE: clojure -m depot.outdated.main [OPTIONS] [FILES]\n")
         (println summary))
 
-      update
-      (if (seq files)
-        (run! #(depot.outdated.update/update-deps-edn! % consider-types)
-              files)
-        (depot.outdated.update/update-deps-edn! "deps.edn" consider-types))
-
       resolve-virtual
       (if (seq files)
         (run! depot.outdated.resolve-virtual/update-deps-edn! files)
         (depot.outdated.resolve-virtual/update-deps-edn! "deps.edn"))
 
       :else
-      (if (seq files)
-        (run! #(depot.outdated.update/check-deps-edn % consider-types) files)
-        (depot.outdated.update/check-deps-edn "deps.edn" consider-types)))
+      (let [files (if (seq files) files ["deps.edn"])]
+        (run! #(depot.outdated.update/apply-new-versions % consider-types aliases overrides update)
+              files)))
     (shutdown-agents)))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -4,8 +4,8 @@
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [depot.outdated :as depot]
-            [depot.outdated.update]
-            [depot.outdated.resolve-virtual]))
+            [depot.outdated.update :as update]
+            [depot.outdated.resolve-virtual :as resolve-virtual]))
 
 (defn comma-str->keywords-set [comma-str]
   (into #{} (map keyword) (str/split comma-str #",")))
@@ -43,8 +43,8 @@
 
       resolve-virtual
       (if (seq files)
-        (run! depot.outdated.resolve-virtual/update-deps-edn! files)
-        (depot.outdated.resolve-virtual/update-deps-edn! "deps.edn"))
+        (run! resolve-virtual/update-deps-edn! files)
+        (resolve-virtual/update-deps-edn! "deps.edn"))
 
       :else
       (let [files (if (seq files) files ["deps.edn"])
@@ -53,6 +53,6 @@
         (when (and every aliases)
           (println "--every and --aliases are mutually exclusive.")
           (System/exit 1))
-        (run! #(depot.outdated.update/apply-new-versions % consider-types check-alias? overrides write)
+        (run! #(update/apply-new-versions % consider-types check-alias? overrides write)
               files)))
     (shutdown-agents)))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -53,9 +53,7 @@
         (depot.outdated.resolve-virtual/update-deps-edn! "deps.edn"))
 
       :else
-      (let [outdated (depot/gather-outdated consider-types aliases overrides)]
-        (if (empty? outdated)
-          (println "All up to date!")
-          (do (pprint/print-table ["Dependency" "Current" "Latest"] outdated)
-              (println)))))
+      (if (seq files)
+        (run! #(depot.outdated.update/check-deps-edn % consider-types) files)
+        (depot.outdated.update/check-deps-edn "deps.edn" consider-types)))
     (shutdown-agents)))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -24,6 +24,7 @@
     :default #{:release}
     :default-desc "release"
     :parse-fn comma-str->keywords-set
+    ;; TODO: check the :errors after parsing for this error
     :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
    ["-o" "--overrides" "Consider overrides for updates instead of pinning to them."]
    ["-u" "--update" "Update deps.edn, or filenames given as additional command line arguments."]

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -23,7 +23,6 @@
     :parse-fn comma-str->keywords-set
     ;; TODO: check the :errors after parsing for this error
     :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
-   ["-o" "--overrides" "Consider overrides for updates instead of pinning to them."]
    ["-e" "--every" "Expand search to all aliases, include overrides."]
    ["-w" "--write" "Instead of just printing changes, write them back to the file."]
    ["-r" "--resolve-virtual" "Convert -SNAPSHOT/RELEASE/LATEST versions into immutable references."]
@@ -38,7 +37,7 @@
                 :no-changes "  All up to date!"}})
 
 (defn -main [& args]
-  (let [{{:keys [aliases consider-types overrides every help write resolve-virtual]} :options
+  (let [{{:keys [aliases consider-types every help write resolve-virtual]} :options
          files :arguments
          summary :summary} (cli/parse-opts args cli-options)]
     (cond
@@ -50,7 +49,6 @@
 
       :else
       (let [files (if (seq files) files ["deps.edn"])
-            overrides (or (when every true) overrides)
             check-alias? (if every (constantly true) (set aliases))
             messages (if resolve-virtual
                        (:resolve-virtual messages)
@@ -61,6 +59,6 @@
         (when (and every aliases)
           (println "--every and --aliases are mutually exclusive.")
           (System/exit 1))
-        (run! #(update/apply-new-versions % consider-types check-alias? overrides write messages new-versions)
+        (run! #(update/apply-new-versions % consider-types check-alias? write messages new-versions)
               files)))
     (shutdown-agents)))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -26,12 +26,12 @@
     :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
    ["-o" "--overrides" "Consider overrides for updates instead of pinning to them."]
    ["-e" "--every" "Expand search to all aliases, include overrides."]
-   ["-u" "--update" "Update deps.edn, or filenames given as additional command line arguments."]
+   ["-w" "--write" "Instead of just printing changes, write them back to the file."]
    ["-r" "--resolve-virtual" "Convert -SNAPSHOT/RELEASE/LATEST versions into immutable references."]
    ["-h" "--help"]])
 
 (defn -main [& args]
-  (let [{{:keys [aliases consider-types overrides every help update resolve-virtual]} :options
+  (let [{{:keys [aliases consider-types overrides every help write resolve-virtual]} :options
          files :arguments
          summary :summary} (cli/parse-opts args cli-options)]
     (cond
@@ -53,6 +53,6 @@
         (when (and every aliases)
           (println "--every and --aliases are mutually exclusive.")
           (System/exit 1))
-        (run! #(depot.outdated.update/apply-new-versions % consider-types check-alias? overrides update)
+        (run! #(depot.outdated.update/apply-new-versions % consider-types check-alias? overrides write)
               files)))
     (shutdown-agents)))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -38,6 +38,7 @@
       help
       (do
         (println "USAGE: clojure -m depot.outdated.main [OPTIONS] [FILES]\n")
+        (println " If no files are given, defaults to using \"deps.edn\".\n")
         (println summary))
 
       resolve-virtual

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -30,6 +30,14 @@
    ["-r" "--resolve-virtual" "Convert -SNAPSHOT/RELEASE/LATEST versions into immutable references."]
    ["-h" "--help"]])
 
+(def ^:private messages
+  {:resolve-virtual {:start-read-only "Checking virtual versions in: %s"
+                     :start-write "Resolving virtual versions in: %s"
+                     :no-changes "  No virtual versions found"}
+   :update-old {:start-read-only "Checking for old versions in: %s"
+                :start-write "Updating old versions in: %s"
+                :no-changes "  All up to date!"}})
+
 (defn -main [& args]
   (let [{{:keys [aliases consider-types overrides every help write resolve-virtual]} :options
          files :arguments
@@ -49,10 +57,11 @@
       :else
       (let [files (if (seq files) files ["deps.edn"])
             overrides (or (when every true) overrides)
-            check-alias? (if every (constantly true) (set aliases))]
+            check-alias? (if every (constantly true) (set aliases))
+            messages (:update-old messages)]
         (when (and every aliases)
           (println "--every and --aliases are mutually exclusive.")
           (System/exit 1))
-        (run! #(update/apply-new-versions % consider-types check-alias? overrides write)
+        (run! #(update/apply-new-versions % consider-types check-alias? overrides write messages)
               files)))
     (shutdown-agents)))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -57,7 +57,7 @@
                        (:update-old messages))
             new-versions (if resolve-virtual
                            resolve-virtual/pinned-versions
-                           update/new-versions)]
+                           depot/newer-versions)]
         (when (and every aliases)
           (println "--every and --aliases are mutually exclusive.")
           (System/exit 1))

--- a/src/depot/outdated/main.clj
+++ b/src/depot/outdated/main.clj
@@ -23,7 +23,7 @@
     :parse-fn comma-str->keywords-set
     ;; TODO: check the :errors after parsing for this error
     :validate [#(set/subset? % depot/version-types) (str "Must be subset of " depot/version-types)]]
-   ["-e" "--every" "Expand search to all aliases, include overrides."]
+   ["-e" "--every" "Expand search to all aliases."]
    ["-w" "--write" "Instead of just printing changes, write them back to the file."]
    ["-r" "--resolve-virtual" "Convert -SNAPSHOT/RELEASE/LATEST versions into immutable references."]
    ["-h" "--help"]])

--- a/src/depot/outdated/resolve_virtual.clj
+++ b/src/depot/outdated/resolve_virtual.clj
@@ -16,7 +16,7 @@
     (.getVersion (.resolveVersion system session request))))
 
 (defn pinned-versions
-  [loc deps-edn]
+  [loc config]
   (let [deps (->> (dzip/lib-loc-seq loc)
                   (filter (fn [loc]
                             (and (not (dzip/ignore-loc? loc))
@@ -29,11 +29,11 @@
                    (when (some (partial str/ends-with? mvn-version) ["-SNAPSHOT" "LATEST" "RELEASE"])
                      [artifact {:version-key :mvn/version
                                 :old-version mvn-version
-                                :new-version (resolve-version artifact coords deps-edn)}]))))
+                                :new-version (resolve-version artifact coords config)}]))))
           deps)))
 
 (defn resolve-all
-  [loc deps-edn]
+  [loc config]
   (dzip/transform-libs
    loc
    (fn [loc]
@@ -42,7 +42,7 @@
            coords (rzip/sexpr coords-loc)]
        (if-let [mvn-version (:mvn/version coords)]
          (if (some (partial str/ends-with? mvn-version) ["-SNAPSHOT" "LATEST" "RELEASE"])
-           (let [version (resolve-version artifact coords deps-edn)]
+           (let [version (resolve-version artifact coords config)]
              (println "   " artifact (:mvn/version coords) "-->" version)
              (dzip/zassoc coords-loc :mvn/version version))
            coords-loc)

--- a/src/depot/outdated/resolve_virtual.clj
+++ b/src/depot/outdated/resolve_virtual.clj
@@ -4,10 +4,10 @@
             [clojure.tools.deps.alpha.util.maven :as maven]
             [clojure.string :as str]))
 
-(defn resolve-version [lib coord {:keys [mvn/repos depot/local-maven-repo]}]
+(defn resolve-version [lib coord {:keys [mvn/repos mvn/local-repo]}]
   (let [artifact     (maven/coord->artifact lib coord)
         system       (maven/make-system)
-        session      (outdated/make-session system (or local-maven-repo maven/default-local-repo))
+        session      (outdated/make-session system (or local-repo maven/default-local-repo))
         remote-repos (mapv maven/remote-repo repos)
         request      (org.eclipse.aether.resolution.VersionRequest. artifact remote-repos nil)]
     (.getVersion (.resolveVersion system session request))))

--- a/src/depot/outdated/resolve_virtual.clj
+++ b/src/depot/outdated/resolve_virtual.clj
@@ -32,33 +32,3 @@
                                 :new-version (resolve-version artifact coords config)}]))))
           deps)))
 
-(defn resolve-all
-  [loc config]
-  (dzip/transform-libs
-   loc
-   (fn [loc]
-     (let [artifact (rzip/sexpr loc)
-           coords-loc (dzip/right loc)
-           coords (rzip/sexpr coords-loc)]
-       (if-let [mvn-version (:mvn/version coords)]
-         (if (some (partial str/ends-with? mvn-version) ["-SNAPSHOT" "LATEST" "RELEASE"])
-           (let [version (resolve-version artifact coords config)]
-             (println "   " artifact (:mvn/version coords) "-->" version)
-             (dzip/zassoc coords-loc :mvn/version version))
-           coords-loc)
-         coords-loc)))))
-
-(defn update-deps-edn! [file]
-  (println "Resolving:" file)
-  (let [deps     (-> (reader/default-deps) reader/read-deps)
-        loc      (rzip/of-file file)
-        old-deps (slurp file)
-        loc'     (resolve-all loc (select-keys deps [:mvn/repos :depot/local-maven-repo]))
-        new-deps (rzip/root-string loc')]
-    (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
-      (if (= old-deps new-deps)
-        (println "  All up to date!")
-        (try
-          (spit file new-deps)
-          (catch java.io.FileNotFoundException e
-            (println "  [ERROR] Permission denied: " file)))))))

--- a/src/depot/outdated/resolve_virtual.clj
+++ b/src/depot/outdated/resolve_virtual.clj
@@ -1,9 +1,6 @@
 (ns depot.outdated.resolve-virtual
-  (:require [clojure.tools.deps.alpha.reader :as reader]
-            [depot.zip :as dzip]
+  (:require [depot.zip :as dzip]
             [depot.outdated :as outdated]
-            [rewrite-clj.zip :as rzip]
-            [clojure.zip :as zip]
             [clojure.tools.deps.alpha.util.maven :as maven]
             [clojure.string :as str]))
 

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -73,66 +73,6 @@
      dzip/exit-meta
      dzip/left)))
 
-(defn update-deps
-  "Update all deps in a `:deps` or `:extra-deps` or `:override-deps` map, at the
-  top level and in aliases.
-
-  `new-versions` is a map of artifact to the to-be-applied updates.
-
-  `loc` points at the top level map."
-  [loc new-versions]
-  (dzip/transform-libs loc (partial apply-new-version new-versions)))
-
-(defn- update-deps-edn*
-  [file consider-types write?]
-  (let [deps (-> (reader/default-deps)
-                 reader/read-deps)
-
-        repos    (select-keys deps [:mvn/repos :mvn/local-repo])
-        loc      (rzip/of-file file)
-        old-deps (slurp file)
-        new-versions (new-versions loc consider-types repos)
-        loc'     (update-deps loc new-versions)
-        new-deps (rzip/root-string loc')]
-    (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
-      (if (= old-deps new-deps)
-        (println "  All up to date!")
-        (try
-          (when write? (spit file new-deps))
-          (catch java.io.FileNotFoundException e
-            (println "  [ERROR] Permission denied: " file)))))))
-
-(defn update-deps-edn!
-  "Destructively update a `deps.edn` file.
-
-  Read a `deps.edn` file, update all dependencies in it to their latest version,
-  unless marked with `^:depot/ignore` metadata, then overwrite the file with the
-  updated version. Preserves whitespace and comments.
-
-  This will consider user and system-wide `deps.edn` files for locating Maven
-  repositories, but only considers the given file when determining current
-  versions.
-
-  `consider-types` is a set, one of [[depot.outdated/version-types]]. "
-  [file consider-types]
-  (println "Updating:" file)
-  (update-deps-edn* file consider-types true))
-
-(defn check-deps-edn
-  "Check for updates to a `deps.edn` file.
-
-  Read a `deps.edn` file, find newer versions of all dependencies in it unless
-  marked with `^:depot/ignore` metadata.
-
-  This will consider user and system-wide `deps.edn` files for locating Maven
-  repositories, but only considers the given file when determining current
-  versions.
-
-  `consider-types` is a set, one of [[depot.outdated/version-types]]. "
-  [file consider-types]
-  (println "Checking:" file)
-  (update-deps-edn* file consider-types false))
-
 (defn- apply-to-deps-map
   "Given a `loc` pointing at a map, and a new-versions map, apply
   any applicable changes, and log them."

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -69,10 +69,11 @@
   "Update all deps in a `:deps` or `:extra-deps` or `:override-deps` map, at the
   top level and in aliases.
 
+  `new-versions` is a map of artifact the to-be-applied updates.
+
   `loc` points at the top level map."
-  [loc consider-types repos]
-  (let [new-versions (new-versions loc consider-types repos)]
-    (dzip/transform-libs loc (partial apply-new-version new-versions))))
+  [loc new-versions]
+  (dzip/transform-libs loc (partial apply-new-version new-versions)))
 
 (defn update-deps-edn!
   "Destructively update a `deps.edn` file.
@@ -94,7 +95,8 @@
         repos    (select-keys deps [:mvn/repos :mvn/local-repo])
         loc      (rzip/of-file file)
         old-deps (slurp file)
-        loc'     (update-deps loc consider-types repos)
+        new-versions (new-versions loc consider-types repos)
+        loc'     (update-deps loc new-versions)
         new-deps (rzip/root-string loc')]
     (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
       (if (= old-deps new-deps)

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -21,6 +21,10 @@
                     (:depot/ignore (meta (rzip/sexpr loc)))))))
 
 (defn- new-versions
+  "Find all deps in a `:deps` or `:extra-deps` or `:override-deps` map to be updated,
+  at the top level and in aliases.
+
+  `loc` points at the top level map."
   [loc consider-types repos]
   (let [deps (->> (dzip/lib-loc-seq loc)
                   (filter (fn [loc]

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -1,6 +1,5 @@
 (ns depot.outdated.update
   (:require [clojure.tools.deps.alpha.reader :as reader]
-            [depot.outdated :as depot]
             [depot.zip :as dzip]
             [rewrite-clj.zip :as rzip]))
 
@@ -10,30 +9,6 @@
        ~@body)
     ;; pre Clojure 1.9
     `(do ~@body)))
-
-(defn new-versions
-  "Find all deps in a `:deps` or `:extra-deps` or `:override-deps` map to be updated,
-  at the top level and in aliases.
-
-  `loc` points at the top level map."
-  [loc config]
-  (dzip/mapped-libs
-   loc
-   (fn [artifact coords]
-     (let [[old-version version-key]
-           (or (some-> coords :mvn/version (vector :mvn/version))
-               (some-> coords :sha (vector :sha)))
-           new-version (-> (depot/current-latest-map artifact
-                                                     coords
-                                                     config)
-                           (get "Latest"))]
-       (when (and old-version
-                  ;; ignore these Maven 2 legacy identifiers
-                  (not (#{"RELEASE" "LATEST"} old-version))
-                  new-version)
-         {:version-key version-key
-          :old-version old-version
-          :new-version new-version})))))
 
 (defn- apply-new-version
   [new-versions loc]

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -124,9 +124,9 @@
                    alias-map)))
 
 (defn apply-new-versions
-  [file consider-types include-alias? include-override-deps? write?]
-  (let [action (if write? "Updating" "Checking")]
-    (printf "%s: %s\n" action file))
+  [file consider-types include-alias? include-override-deps? write? messages]
+  (let [start-message ((if write? :start-write :start-read-only) messages)]
+    (printf (str start-message "\n") file))
   (let [deps (reader/read-deps (reader/default-deps))
         repos    (select-keys deps [:mvn/repos :mvn/local-repo])
         loc      (rzip/of-file file)
@@ -140,7 +140,7 @@
         new-deps (rzip/root-string loc')]
     (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
       (if (= old-deps new-deps)
-        (println "  All up to date!")
+        (println (:no-changes messages))
         (try
           (when write? (spit file new-deps))
           (catch java.io.FileNotFoundException e

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -69,7 +69,7 @@
   "Update all deps in a `:deps` or `:extra-deps` or `:override-deps` map, at the
   top level and in aliases.
 
-  `new-versions` is a map of artifact the to-be-applied updates.
+  `new-versions` is a map of artifact to the to-be-applied updates.
 
   `loc` points at the top level map."
   [loc new-versions]

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -2,8 +2,7 @@
   (:require [clojure.tools.deps.alpha.reader :as reader]
             [depot.outdated :as depot]
             [depot.zip :as dzip]
-            [rewrite-clj.zip :as rzip]
-            [clojure.zip :as zip]))
+            [rewrite-clj.zip :as rzip]))
 
 (defmacro with-print-namespace-maps [bool & body]
   (if (find-var 'clojure.core/*print-namespace-maps*)

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -11,15 +11,6 @@
     ;; pre Clojure 1.9
     `(do ~@body)))
 
-(defn update-loc?
-  "Should the version at the current position be updated?
-  Returns true unless any ancestor has the `^:depot/ignore` metadata."
-  [loc]
-  (not (rzip/find loc
-                  rzip/up
-                  (fn [loc]
-                    (:depot/ignore (meta (rzip/sexpr loc)))))))
-
 (defn- new-versions
   "Find all deps in a `:deps` or `:extra-deps` or `:override-deps` map to be updated,
   at the top level and in aliases.
@@ -28,8 +19,8 @@
   [loc {:keys [consider-types repos]}]
   (let [deps (->> (dzip/lib-loc-seq loc)
                   (filter (fn [loc]
-                            (and (update-loc? loc)
-                                 (update-loc? (dzip/right loc)))))
+                            (and (not (dzip/ignore-loc? loc))
+                                 (not (dzip/ignore-loc? (dzip/right loc))))))
                   (map dzip/loc->lib)
                   doall)]
     (into {}

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -25,7 +25,7 @@
   at the top level and in aliases.
 
   `loc` points at the top level map."
-  [loc consider-types repos]
+  [loc {:keys [consider-types repos]}]
   (let [deps (->> (dzip/lib-loc-seq loc)
                   (filter (fn [loc]
                             (and (update-loc? loc)
@@ -131,7 +131,8 @@
         repos    (select-keys deps [:mvn/repos :mvn/local-repo])
         loc      (rzip/of-file file)
         old-deps (slurp file)
-        new-versions (new-versions loc consider-types repos)
+        new-versions (new-versions loc {:consider-types consider-types
+                                        :repos repos})
         loc'     (-> loc
                      (apply-top-level-deps (partial apply-new-version new-versions))
                      (apply-aliases-deps include-alias?

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -136,21 +136,26 @@
    to the top-level dependencies."
   [loc new-versions]
   (-> loc
-      (rzip/get :deps)
+      (dzip/zget :deps)
+      dzip/enter-meta
       (apply-to-deps-map  new-versions)
-      rzip/up))
+      dzip/exit-meta))
 
 (defn- apply-alias-deps
   [loc include-override-deps? new-versions]
   (cond-> loc
-    (rzip/get loc :extra-deps)
-    (-> (rzip/get :extra-deps)
+    (dzip/zget loc :extra-deps)
+    (-> (dzip/zget :extra-deps)
+        dzip/enter-meta
         (apply-to-deps-map new-versions)
+        dzip/exit-meta
         rzip/up)
 
-    (and include-override-deps? (rzip/get loc :override-deps))
-    (-> (rzip/get :override-deps)
+    (and include-override-deps? (dzip/zget loc :override-deps))
+    (-> (dzip/zget :override-deps)
+        dzip/enter-meta
         (apply-to-deps-map new-versions)
+        dzip/exit-meta
         rzip/up)))
 
 (defn- apply-aliases-deps
@@ -162,7 +167,9 @@
                        (if (contains? aliases alias-name)
                          (-> loc
                              rzip/right
+                             dzip/enter-meta
                              (apply-alias-deps include-override-deps? new-versions)
+                             dzip/exit-meta
                              rzip/left)
                          loc)))
                    alias-map)))

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -75,6 +75,25 @@
   [loc new-versions]
   (dzip/transform-libs loc (partial apply-new-version new-versions)))
 
+(defn- update-deps-edn*
+  [file consider-types write?]
+  (let [deps (-> (reader/default-deps)
+                 reader/read-deps)
+
+        repos    (select-keys deps [:mvn/repos :mvn/local-repo])
+        loc      (rzip/of-file file)
+        old-deps (slurp file)
+        new-versions (new-versions loc consider-types repos)
+        loc'     (update-deps loc new-versions)
+        new-deps (rzip/root-string loc')]
+    (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
+      (if (= old-deps new-deps)
+        (println "  All up to date!")
+        (try
+          (when write? (spit file new-deps))
+          (catch java.io.FileNotFoundException e
+            (println "  [ERROR] Permission denied: " file)))))))
+
 (defn update-deps-edn!
   "Destructively update a `deps.edn` file.
 
@@ -89,19 +108,19 @@
   `consider-types` is a set, one of [[depot.outdated/version-types]]. "
   [file consider-types]
   (println "Updating:" file)
-  (let [deps (-> (reader/default-deps)
-                 reader/read-deps)
+  (update-deps-edn* file consider-types true))
 
-        repos    (select-keys deps [:mvn/repos :mvn/local-repo])
-        loc      (rzip/of-file file)
-        old-deps (slurp file)
-        new-versions (new-versions loc consider-types repos)
-        loc'     (update-deps loc new-versions)
-        new-deps (rzip/root-string loc')]
-    (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
-      (if (= old-deps new-deps)
-        (println "  All up to date!")
-        (try
-          (spit file new-deps)
-          (catch java.io.FileNotFoundException e
-            (println "  [ERROR] Permission denied: " file)))))))
+(defn check-deps-edn
+  "Check for updates to a `deps.edn` file.
+
+  Read a `deps.edn` file, find newer versions of all dependencies in it unless
+  marked with `^:depot/ignore` metadata.
+
+  This will consider user and system-wide `deps.edn` files for locating Maven
+  repositories, but only considers the given file when determining current
+  versions.
+
+  `consider-types` is a set, one of [[depot.outdated/version-types]]. "
+  [file consider-types]
+  (println "Checking:" file)
+  (update-deps-edn* file consider-types false))

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -80,7 +80,7 @@
     (printf (str start-message "\n") file))
   (let [deps (reader/read-deps (reader/default-deps))
         config (-> deps
-                   (select-keys [:mvn/repos :depot/local-maven-repo])
+                   (select-keys [:mvn/repos :mvn/local-repo])
                    (assoc :consider-types consider-types))
         loc      (rzip/of-file file)
         old-deps (slurp file)

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -119,7 +119,7 @@
   (let [start-message ((if write? :start-write :start-read-only) messages)]
     (printf (str start-message "\n") file))
   (let [deps (reader/read-deps (reader/default-deps))
-        repos    (select-keys deps [:mvn/repos :mvn/local-repo])
+        repos    (select-keys deps [:mvn/repos :depot/local-maven-repo])
         loc      (rzip/of-file file)
         old-deps (slurp file)
         new-versions (new-versions loc {:consider-types consider-types

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -169,11 +169,11 @@
 
 (defn- apply-aliases-deps
   "`loc` points to the root of the deps.edn file."
-  [loc aliases include-override-deps? new-versions]
+  [loc include-alias? include-override-deps? new-versions]
   (let [alias-map (dzip/zget loc :aliases)]
     (dzip/map-keys (fn [loc]
                      (let [alias-name (rzip/sexpr loc)]
-                       (if (contains? aliases alias-name)
+                       (if (include-alias? alias-name)
                          (-> loc
                              rzip/right
                              dzip/enter-meta
@@ -184,7 +184,7 @@
                    alias-map)))
 
 (defn apply-new-versions
-  [file consider-types aliases include-override-deps? write?]
+  [file consider-types include-alias? include-override-deps? write?]
   (let [action (if write? "Updating" "Checking")]
     (printf "%s: %s\n" action file))
   (let [deps (reader/read-deps (reader/default-deps))
@@ -194,7 +194,7 @@
         new-versions (new-versions loc consider-types repos)
         loc'     (-> loc
                      (apply-top-level-deps new-versions)
-                     (apply-aliases-deps aliases include-override-deps? new-versions))
+                     (apply-aliases-deps include-alias? include-override-deps? new-versions))
         new-deps (rzip/root-string loc')]
     (when (and loc' new-deps) ;; defensive check to prevent writing an empty deps.edn
       (if (= old-deps new-deps)

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -11,7 +11,7 @@
     ;; pre Clojure 1.9
     `(do ~@body)))
 
-(defn- new-versions
+(defn new-versions
   "Find all deps in a `:deps` or `:extra-deps` or `:override-deps` map to be updated,
   at the top level and in aliases.
 
@@ -114,7 +114,7 @@
                    alias-map)))
 
 (defn apply-new-versions
-  [file consider-types include-alias? include-override-deps? write? messages]
+  [file consider-types include-alias? include-override-deps? write? messages new-versions]
   (let [start-message ((if write? :start-write :start-read-only) messages)]
     (printf (str start-message "\n") file))
   (let [deps (reader/read-deps (reader/default-deps))

--- a/src/depot/zip.clj
+++ b/src/depot/zip.clj
@@ -177,3 +177,19 @@
       (let [loc (-> (apply f loc' args) znext)]
         (recur loc (next-lib loc)))
       loc)))
+
+(defn mapped-libs
+  "Find every unignored dep in a `:deps` or `:extra-deps` or `:override-deps` map, at
+   the top level and in aliases, and return a map of artifact to output of
+  (f artifact coords). f must be free of side-effects.
+
+  `loc` points at the top level map."
+  [loc f]
+  (->> (lib-loc-seq loc)
+       (filter (fn [loc]
+                 (and (not (ignore-loc? loc))
+                      (not (ignore-loc? (right loc))))))
+       (map loc->lib)
+       (pmap (fn [[artifact coords]]
+               [artifact (f artifact coords)]))
+       (into {})))

--- a/src/depot/zip.clj
+++ b/src/depot/zip.clj
@@ -34,6 +34,26 @@
   [loc]
   (some-> loc rzip/next (zip-skip-ws rzip/next rzip/right rzip/end?)))
 
+(defn enter-meta
+  "If the given `loc` is a meta node, navigate down to the value to which it is attached,
+  else return the `loc`."
+  [loc]
+  (if (not= :meta (rzip/tag loc))
+    loc
+    (-> loc
+        rzip/down
+        right
+        (recur))))
+
+(defn exit-meta
+  "If the given `loc`'s parent is a meta node, return the first ancestor whose parent is not,
+  else return the `loc`."
+  [loc]
+  (let [loc' (rzip/up loc)]
+    (if (= :meta (rzip/tag loc'))
+      (recur loc')
+      loc)))
+
 (defn zget
   "Like [[clojure.core/get]], but for a zipper over a map.
 

--- a/src/depot/zip.clj
+++ b/src/depot/zip.clj
@@ -119,6 +119,16 @@
         (recur (right (right v)) (rzip/up v))
         (recur (right (right loc)) parent)))))
 
+(defn ignore-loc?
+  "Should the version at the current position be ignored?
+  Returns true if any ancestor has the `^:depot/ignore` metadata."
+  [loc]
+  (boolean
+   (rzip/find loc
+              rzip/up
+              (fn [loc]
+                (:depot/ignore (meta (rzip/sexpr loc)))))))
+
 ;; TODO make sure this only matches map keys
 (defn lib?
   "Is the loc at a library name."

--- a/test/depot/outdated/resolve_virtual_test.clj
+++ b/test/depot/outdated/resolve_virtual_test.clj
@@ -6,20 +6,6 @@
             [clojure.string :as str]
             [depot.zip :as dzip]))
 
-(deftest resolve-all-test
-  (is (= '{:deps
-           {org.clojure/clojure {:mvn/version "1.10.0"},
-            cider/piggieback    {:mvn/version "0.4.1-20190222.154954-1"}}}
-         (with-redefs [r/resolve-version (fn [lib _ _]
-                                           ('{org.clojure/clojure "1.10.0"
-                                              cider/piggieback    "0.4.1-20190222.154954-1"} lib))]
-           (-> "{:deps {org.clojure/clojure {:mvn/version \"LATEST\"}
-cider/piggieback {:mvn/version \"0.4.1-SNAPSHOT\"}}}"
-               rzip/of-string
-               (r/resolve-all maven/standard-repos)
-               rzip/root
-               rewrite-clj.node.protocols/sexpr)))))
-
 (deftest resolve-version-test
   (is
    (str/starts-with? (r/resolve-version 'cider/piggieback

--- a/test/depot/outdated/resolve_virtual_test.clj
+++ b/test/depot/outdated/resolve_virtual_test.clj
@@ -24,5 +24,5 @@ cider/piggieback {:mvn/version \"0.4.1-SNAPSHOT\"}}}"
   (is
    (str/starts-with? (r/resolve-version 'cider/piggieback
                                         {:mvn/version "0.4.1-SNAPSHOT"}
-                                        maven/standard-repos)
+                                        {:mvn/repos maven/standard-repos})
                      "0.4.1-20")))

--- a/test/depot/outdated/update_test.clj
+++ b/test/depot/outdated/update_test.clj
@@ -9,15 +9,3 @@
 
 (def REPOS {:mvn/repos maven/standard-repos})
 
-(deftest update-loc?-test
-  (testing "don't update when tagged with :depot/ignore"
-    (is (false? (u/update-loc?
-                 (rzip/find-value (rzip/of-string "{:aliases {:dev ^:depot/ignore {:deps {foo/bar {}}}}} :test {:deps {baz/baq {}}}")
-                                  rzip/next
-                                  'foo/bar)))))
-
-  (testing "do update by default"
-    (is (true? (u/update-loc?
-                (rzip/find-value (rzip/of-string "{:aliases {:dev ^:depot/ignore {:deps {foo/bar {}}}}} :test {:deps {baz/baq {}}}")
-                                 rzip/next
-                                 'baz/baq))))))

--- a/test/depot/outdated/update_test.clj
+++ b/test/depot/outdated/update_test.clj
@@ -21,31 +21,3 @@
                 (rzip/find-value (rzip/of-string "{:aliases {:dev ^:depot/ignore {:deps {foo/bar {}}}}} :test {:deps {baz/baq {}}}")
                                  rzip/next
                                  'baz/baq))))))
-
-(deftest update-deps-test
-  (is (= '{:deps {org.clojure/algo.monads {:mvn/version "0.1.6"}}}
-
-         (-> (rzip/edn (node/coerce '{:deps {org.clojure/algo.monads {:mvn/version "0.1.4"}}}))
-             (rzip/down)
-             (rzip/right)
-             (u/update-deps CONSIDER_TYPES_RELEASES REPOS)
-             (rzip/root)
-             (node/sexpr))))
-
-  (testing "it skips over uneval nodes"
-    (is (= '{:deps {org.clojure/algo.monads {:mvn/version "0.1.6"}}}
-           (-> (rzip/of-string "{:deps {org.clojure/algo.monads #_foo {:mvn/version \"0.1.4\"}}}")
-               (rzip/down)
-               (rzip/right)
-               (u/update-deps CONSIDER_TYPES_RELEASES REPOS)
-               (rzip/root)
-               (node/sexpr)))))
-
-  (testing "it ignores empty maps"
-    (is (= '{:deps {}}
-           (-> (rzip/edn (node/coerce '{:deps {}}))
-               (rzip/down)
-               (rzip/right)
-               (u/update-deps CONSIDER_TYPES_RELEASES REPOS)
-               (rzip/root)
-               (node/sexpr))))))

--- a/test/depot/zip_test.clj
+++ b/test/depot/zip_test.clj
@@ -52,3 +52,31 @@
            (-> loc
                (u/zassoc :baq 123)
                rzip/root-string)))))
+
+(deftest lib-loc-seq-test
+  (let [loc (rzip/of-string (pr-str '{:deps
+                                      {foo {:mvn/version "1.0"}}
+                                      :aliases
+                                      {:test
+                                       {:extra-deps {bar {:mvn/version "1.9.8"}}}}}))
+        loc-seq (u/lib-loc-seq loc)]
+    (is (= 2
+           (count loc-seq)))
+
+    (is (= (-> loc
+               rzip/down
+               rzip/right
+               rzip/down)
+           (first loc-seq)))
+
+    (is (= (-> loc
+             rzip/down
+             rzip/right
+             rzip/right
+             rzip/right
+             rzip/down
+             rzip/right
+             rzip/down
+             rzip/right
+             rzip/down)
+         (second loc-seq)))))

--- a/test/depot/zip_test.clj
+++ b/test/depot/zip_test.clj
@@ -4,6 +4,27 @@
             [rewrite-clj.node :as node]
             [clojure.test :refer :all]))
 
+(deftest enter-meta-test
+  (are [input] (= :map (-> (rzip/of-string input)
+                           (rzip/get :d)
+                           (u/enter-meta)
+                           (rzip/tag)))
+    "{:d {:a 0 :b 1}}"
+    "{:d ^:depot/ignore {:a 0 :b 1}}"
+    "{:d ^:depot/ignore ^:foo/bar {:a 0 :b 1}}"))
+
+(deftest exit-meta-test
+  (are [input] (= {:d {:a 0 :b 1}}
+                  (-> (rzip/of-string input)
+                      (rzip/get :d)
+                      (u/enter-meta)
+                      (u/exit-meta)
+                      (rzip/up)
+                      (rzip/sexpr)))
+    "{:d {:a 0 :b 1}}"
+    "{:d ^:depot/ignore {:a 0 :b 1}}"
+    "{:d ^:depot/ignore ^:foo/bar {:a 0 :b 1}}"))
+
 (deftest right-test
   (is (= :y
          (-> (rzip/of-string "[:x   ,,#_123\n  :y]")

--- a/test/depot/zip_test.clj
+++ b/test/depot/zip_test.clj
@@ -101,3 +101,16 @@
              rzip/right
              rzip/down)
          (second loc-seq)))))
+
+(deftest ignore-loc?-test
+  (testing "don't update when tagged with :depot/ignore"
+    (is (true? (u/ignore-loc?
+                 (rzip/find-value (rzip/of-string "{:aliases {:dev ^:depot/ignore {:deps {foo/bar {}}}}} :test {:deps {baz/baq {}}}")
+                                  rzip/next
+                                  'foo/bar)))))
+
+  (testing "do update by default"
+    (is (false? (u/ignore-loc?
+                (rzip/find-value (rzip/of-string "{:aliases {:dev ^:depot/ignore {:deps {foo/bar {}}}}} :test {:deps {baz/baq {}}}")
+                                 rzip/next
+                                 'baz/baq))))))

--- a/test/depot/zip_test.clj
+++ b/test/depot/zip_test.clj
@@ -114,3 +114,17 @@
                 (rzip/find-value (rzip/of-string "{:aliases {:dev ^:depot/ignore {:deps {foo/bar {}}}}} :test {:deps {baz/baq {}}}")
                                  rzip/next
                                  'baz/baq))))))
+
+(deftest mapped-libs-test
+  (let [loc (rzip/edn
+             (node/coerce
+              '{:deps {org.clojure/clojure {:mvn/version "1.10.1"}}
+                :aliases {:dev {:extra-deps {foo.bar {:git/sha "abiglonghash"}}}
+                          :test {:extra-deps {foo.baz {:mvn/version "1.2.3"}}
+                                 :override-deps {foo.baz.sublib {:mvn/version "1.2.2"}}}}}))]
+    (is (= '{org.clojure/clojure [org.clojure/clojure {:mvn/version "1.10.1"}]
+             foo.bar [foo.bar {:git/sha "abiglonghash"}]
+             foo.baz [foo.baz {:mvn/version "1.2.3"}]
+             foo.baz.sublib [foo.baz.sublib {:mvn/version "1.2.2"}]}
+           (u/mapped-libs loc (fn [& args] args))))
+    (is (every? nil? (vals (u/mapped-libs loc (constantly nil)))))))


### PR DESCRIPTION
This is a sprawling PR that attempts to address #12.

There's no way to unify the behavior of the the two subsystems without one of them breaking compatibility with the current (1.8.4) behavior.

Here's the highlights of what's changed from an end user perspective (copied straight from the CHANGELOG.md)

* **Breaking** Replaced the `--update` flag with the `--write` flag.
* **Breaking** Changed scoping rules to be the same with or without the `--write` flag
* **Breaking** Remove support for the `--overrides` flag. `:override-deps` will be checked by default.
  To ignore them, use the `:depot/ignore` metadata.
* **Breaking** Changed scoping rules to be the same with or without the `--resolve-virtual` flag
* **Breaking** Changed `--resolve-virtual` to be read-only unless combined with `--write`
* Fixed inconsistent output styles
* Added the `--every` flag which allows checking all aliases at once

Input that I'd love to receive:
- Behavior: Do folks have concerns about the changes in semantics? 
- Scope: Would you like to see this PR broken into multiple, smaller PRs? Are there more changes you'd like to see while we're breaking backwards compatibility anyway?
- Bugs: My use cases for this tool are pretty simple, so it's totally possible that I've missed a bunch of edge cases.

And of course, suggestions on code style and pretty much anything else are welcome as well.

