### PR TITLE
Handle empty coordinate maps

### DIFF
--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -20,15 +20,15 @@
          new-version :new-version
          old-version :old-version :as v} (get new-versions artifact)]
     (->
-     (if (not v)
-       coords-loc
-       (do (with-print-namespace-maps false
-             (println " "
-                      artifact
-                      (pr-str {version-key old-version})
-                      "->"
-                      (pr-str {version-key new-version})))
-           (dzip/zassoc coords-loc version-key new-version)))
+     (if v
+       (with-print-namespace-maps false
+         (println " "
+                  artifact
+                  (pr-str {version-key old-version})
+                  "->"
+                  (pr-str {version-key new-version}))
+         (dzip/zassoc coords-loc version-key new-version))
+       coords-loc)
      dzip/exit-meta
      dzip/left)))
 

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -20,7 +20,7 @@
          new-version :new-version
          old-version :old-version :as v} (get new-versions artifact)]
     (->
-     (if v
+     (if (and v (seq (rzip/sexpr coords-loc)))
        (with-print-namespace-maps false
          (println " "
                   artifact

--- a/test/depot/outdated/update_test.clj
+++ b/test/depot/outdated/update_test.clj
@@ -16,3 +16,14 @@
            (#'u/apply-top-level-deps
             input
             identity)))))
+
+(deftest empty-coordinate-map
+  (let [loc (-> (node/coerce {'org.clojure/clojure {}})
+                rzip/edn
+                rzip/down)
+        result (#'u/apply-new-version {'org.clojure/clojure {:old-version "1.10.0"
+                                                             :new-version "1.10.1"
+                                                             :version-key :mvn/version}}
+                                      loc)]
+    (is (= loc
+           result))))

--- a/test/depot/outdated/update_test.clj
+++ b/test/depot/outdated/update_test.clj
@@ -3,7 +3,6 @@
             [depot.outdated.update :as u]
             [rewrite-clj.node :as node]
             [rewrite-clj.zip :as rzip]
-            [rewrite-clj.node :as node]
             [clojure.tools.deps.alpha.util.maven :as maven]))
 
 (def CONSIDER_TYPES_RELEASES #{:release})


### PR DESCRIPTION
Includes the single commit from #29.

Fixes #30.

Given `deps.edn` as per the bug report:
```clojure
{:deps {org.clojure/clojure {}}
 :aliases {:newer-stuff
           {:override-deps {org.clojure/clojure {:mvn/version "1.10.0"}}}}}
```
---
Invoking depot with no args prints:
```
Checking for old versions in: deps.edn
  All up to date!
```
---
Invoking with `--write`
```
Updating old versions in: deps.edn
  All up to date!
```
and leaves the file unchanged.

---
Invoking with `--every`:
```
Checking for old versions in: deps.edn
  org.clojure/clojure {:mvn/version "1.10.0"} -> {:mvn/version "1.10.1"}
```
---
Invoking with `--every` and `--write`:
```
Updating old versions in: deps.edn
  org.clojure/clojure {:mvn/version "1.10.0"} -> {:mvn/version "1.10.1"}
```
and the file is now
```clojure
{:deps {org.clojure/clojure {}}
 :aliases {:newer-stuff
           {:override-deps {org.clojure/clojure {:mvn/version "1.10.1"}}}}}
```

