### PR TITLE
Bump Deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,8 @@
 
  :deps
  {org.clojure/clojure {:mvn/version "1.10.1"}
-  org.clojure/tools.deps.alpha {:mvn/version "0.7.516"}
-  org.clojure/tools.cli {:mvn/version "0.4.2"}
+  org.clojure/tools.deps.alpha {:mvn/version "0.8.677"}
+  org.clojure/tools.cli {:mvn/version "1.0.194"}
   rewrite-clj {:mvn/version "0.6.1"}
   version-clj {:mvn/version "0.1.2"}}
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,27 +20,22 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>clojurescript</artifactId>
-      <version>1.10.520</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>tools.deps.alpha</artifactId>
-      <version>0.7.516</version>
+      <version>1.10.1</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.cli</artifactId>
-      <version>0.4.1</version>
+      <version>1.0.194</version>
     </dependency>
     <dependency>
       <groupId>rewrite-clj</groupId>
       <artifactId>rewrite-clj</artifactId>
       <version>0.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>tools.deps.alpha</artifactId>
+      <version>0.8.677</version>
     </dependency>
     <dependency>
       <groupId>version-clj</groupId>


### PR DESCRIPTION
Mainly, bring in the latest tools.deps.alpha, due to the prior version
(referenced in this project) that was incorrectly bringing in the slf4j NOP
implementation. The newer tools.deps.alpha doesn't have that dependency
included.

-=david=-