### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ I'd recommend adding depot as an alias in your own `deps.edn` file, this will al
 
 ```clojure
 {:deps {}
- :aliases {:outdated {:extra-deps {olical/depot {:mvn/version "..."}}
+ :aliases {:outdated {:replace-deps {olical/depot {:mvn/version "..."}}
                       :main-opts ["-m" "depot.outdated.main"]}}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Find newer versions of your dependencies in your `deps.edn` file using the [Cloj
 You can try it out easily with this one liner:
 
 ```bash
-$ clojure -Sdeps '{:deps {olical/depot {:mvn/version "2.0.1"}}}' -m depot.outdated.main
+$ clojure -Sdeps '{:aliases {:outdated {:replace-deps {olical/depot {:mvn/version "2.0.1"}}}}}' -M:outdated -m depot.outdated.main
 Checking for old versions in: deps.edn
   org.clojure/clojure {:mvn/version "1.9.0"} -> {:mvn/version "1.10.1"}
 ```

--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,7 @@
   {:extra-deps {;; Only here to check depot functionality.
                 org.slf4j/slf4j-simple {:mvn/version "1.7.30"}
                 clj-time {:mvn/version "0.15.2"}
-                cider/cider-nrepl {:mvn/version "0.22.0"}
+                cider/cider-nrepl {:mvn/version "0.25.5"}
                 olical/cljs-test-runner {:git/url "https://github.com/Olical/cljs-test-runner.git"
                                          :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure {:mvn/version "1.10.1"}
-  org.clojure/tools.deps.alpha {:mvn/version "0.8.677"}
+  org.clojure/tools.deps.alpha {:mvn/version "0.9.857"}
   org.clojure/tools.cli {:mvn/version "1.0.194"}
   rewrite-clj {:mvn/version "0.6.1"}
   version-clj {:mvn/version "0.1.2"}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,8 +4,8 @@
  {org.clojure/clojure {:mvn/version "1.10.1"}
   org.clojure/tools.deps.alpha {:mvn/version "0.9.857"}
   org.clojure/tools.cli {:mvn/version "1.0.194"}
-  rewrite-clj {:mvn/version "0.6.1"}
-  version-clj {:mvn/version "0.1.2"}}
+  rewrite-clj/rewrite-clj {:mvn/version "0.6.1"}
+  version-clj/version-clj {:mvn/version "0.1.2"}}
 
  :aliases
  {:cider
@@ -20,7 +20,7 @@
   :test
   {:extra-deps {;; Only here to check depot functionality.
                 org.slf4j/slf4j-simple {:mvn/version "1.7.30"}
-                clj-time {:mvn/version "0.15.2"}
+                clj-time/clj-time {:mvn/version "0.15.2"}
                 cider/cider-nrepl {:mvn/version "0.25.5"}
                 olical/cljs-test-runner {:git/url "https://github.com/Olical/cljs-test-runner.git"
                                          :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -1,5 +1,5 @@
 (ns depot.outdated.update
-  (:require [clojure.tools.deps.alpha.reader :as reader]
+  (:require [clojure.tools.deps.alpha :as deps.alpha]
             [depot.zip :as dzip]
             [rewrite-clj.zip :as rzip]))
 
@@ -77,7 +77,8 @@
   [file consider-types include-alias? write? messages new-versions]
   (let [start-message ((if write? :start-write :start-read-only) messages)]
     (printf (str start-message "\n") file))
-  (let [deps (reader/read-deps (reader/default-deps))
+  (let [{:keys [root-edn user-edn project-edn]} (deps.alpha/find-edn-maps)
+        deps (deps.alpha/merge-edns [root-edn user-edn project-edn])
         config (-> deps
                    (select-keys [:mvn/repos :mvn/local-repo])
                    (assoc :consider-types consider-types))


### PR DESCRIPTION
I updated it because I came across an issue where I had

```
org.clojure/tools.deps.alpha {:mvn/version "0.9.857"}
```

declared in a project's deps.edn.

I used the setup as per the README in my ~/.clojure/deps.edn:

```clojure
:aliases {:outdated {:extra-deps {olical/depot {:mvn/version "2.0.1"}}
          :main-opts ["-m" "depot.outdated.main"]}}
```

and I got an error:
```
Syntax error (FileNotFoundException) compiling at (depot/outdated/update.clj:1:1).
Could not locate clojure/tools/deps/alpha/reader__init.class, clojure/tools/deps/alpha/reader.clj 
or clojure/tools/deps/alpha/reader.cljc on classpath.
```
Then collected the info about it and was about to create a new issue
when I saw this issue about API change in tools.deps.alpha:
#46 and kind of "got distracted" and upgraded the dependencies, 
creating this PR.

But really, all I had to do was change the above alias to:
```clojure
:aliases {:outdated {:replace-deps {olical/depot {:mvn/version "2.0.1"}}
                     :main-opts ["-m" "depot.outdated.main"]}}
```
NOTE: `:replace-deps` instead of `:extra-deps`.

Then I updated more dependencies and fully qualified existing artifacts to suppress warnings.