### PR TITLE
Dogfood: Automate dependency checking

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,58 @@
+name: dependencies
+on:
+  schedule:
+    - cron: "29 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Install Clojure CLI
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.10.1.763'
+      - name: check for outdated dependencies
+        id: deps
+        run: |
+          echo 'Scheduled outdated dependency check:' >> outdated.md
+          echo '```clojure' >> outdated.md
+          clojure -M:outdated >> outdated.md
+          echo '```' >> outdated.md
+          cat outdated.md
+          if [ $(grep -c ':mvn/version' outdated.md) -gt 0 ]; then echo ::set-output name=status::failure; else echo ::set-output name=status::success; fi
+      - if: ${{ steps.deps.outputs.status == 'failure' }}
+        name: Badge
+        uses: RubbaBoy/BYOB@v1.2.0
+        with:
+          NAME: dependencies
+          LABEL: 'dependencies'
+          STATUS: "out of date"
+          COLOR: red
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: ${{ steps.deps.outputs.status == 'success' }}
+        name: Badge
+        uses: RubbaBoy/BYOB@v1.2.0
+        with:
+          NAME: dependencies
+          LABEL: 'dependencies'
+          STATUS: 'up to date'
+          COLOR: green
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: ${{ steps.deps.outputs.status == 'failure' }}
+        name: Update stale dependencies
+        run: clojure -M:outdated --write
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Updating stale dependencies
+          title: Update stale dependencies
+          body: Updating dependencies to the latest stable versions
+          branch: update-dependencies
+          base: master

--- a/deps.edn
+++ b/deps.edn
@@ -26,4 +26,6 @@
                                          :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}
 
                 ;; Actually here to run tests.
-                lambdaisland/kaocha {:mvn/version "1.0.632"}}}}}
+                lambdaisland/kaocha {:mvn/version "1.0.632"}}}
+  :outdated {:replace-deps {olical/depot {:mvn/version "RELEASE"}}
+             :main-opts ["-m" "depot.outdated.main"]}}}


### PR DESCRIPTION
tl;dr I created a workflow that checks the dependencies of the project
using depot and creates a PR to update the dependencies.

I figured that it would be nice for depot to keep an eye on itself and
check if any of its dependencies get stale.

I don't know what your feelings are towards GitHub actions, but seeing
how the project is on GitHub it made sense to me to create an
automated workflow which would check the dependencies of depot, using
depot.

In the PR I've included the steps for creating the badge that can be
displayed in the README showing if the dependencies are up to date or
not. But before I go and do that, do is this something you think that
the project could use?

If you like this change, maybe I can add one that runs tests also,
that way the code can be checked each time somebody makes a PR or you
merge into master.

What do you think?