### PR TITLE
Simplify clojure command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,16 @@ Find newer versions of your dependencies in your `deps.edn` file using the [Cloj
 You can try it out easily with this one liner:
 
 ```bash
-$ clojure -Sdeps '{:aliases {:outdated {:replace-deps {olical/depot {:mvn/version "2.2.0"}}}}}' -M:outdated -m depot.outdated.main
+$ clojure -Sdeps '{:deps {olical/depot {:mvn/version "RELEASE"}}}' -m depot.outdated.main
 Checking for old versions in: deps.edn
   org.clojure/clojure {:mvn/version "1.9.0"} -> {:mvn/version "1.10.1"}
 ```
 
 I'd recommend adding depot as an alias in your own `deps.edn` file, this will allow it to check itself for updates:
 
-> Note: Replace the ellipsis with the current version shown above.
-
 ```clojure
 {:deps {}
- :aliases {:outdated {:replace-deps {olical/depot {:mvn/version "..."}}
+ :aliases {:outdated {:replace-deps {olical/depot {:mvn/version "2.2.0"}}
                       :main-opts ["-m" "depot.outdated.main"]}}}
 ```
 


### PR DESCRIPTION
Another option would be to change the version to the `RELEASE` tag, and add a note about replacing it with latest release if wanted. Do you want me to make such change @Olical?