### PR TITLE
Solve #54: Adds default-deps to keys checked for aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ $ clojure -Aoutdated ../my-project/deps.edn
 
 By default, only dependencies under the top-level `:deps` are considered.
 
-To also consider `:extra-deps` and `:override-deps` under aliases, see
-the the `--aliases` and `--every` flags.
+To also consider `:default-deps`, `:extra-deps` and `:override-deps` under aliases,
+use the `--aliases alias1,alias2` to specify alias,
+or the `--every` flag to consider all aliases.
 
 To prevent Depot from touching certain parts of your `deps.edn`, mark
 them with the `^:depot/ignore` metadata.

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -102,7 +102,7 @@
   (-current-latest-map lib coord config))
 
 (defn newer-versions
-  "Find all deps in a `:deps` or `:extra-deps` or `:override-deps` map to be updated,
+  "Find all deps in a `:deps` or `:default-deps` or `:extra-deps` or `:override-deps` map to be updated,
   at the top level and in aliases.
 
   `loc` points at the top level map."

--- a/src/depot/outdated/resolve_virtual.clj
+++ b/src/depot/outdated/resolve_virtual.clj
@@ -13,7 +13,7 @@
     (.getVersion (.resolveVersion system session request))))
 
 (defn pinned-versions
-  "Find all deps in a `:deps` or `:extra-deps` or `:override-deps` map to be pinned,
+  "Find all deps in a `:deps` or `:default-deps` or `:extra-deps` or `:override-deps` map to be pinned,
   at the top level and in aliases.
 
   `loc` points at the top level map."

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -53,6 +53,7 @@
 (defn- apply-alias-deps
   [loc f]
   (-> loc
+      (apply-to-deps-map :default-deps f)
       (apply-to-deps-map :extra-deps f)
       (apply-to-deps-map :override-deps f)))
 

--- a/src/depot/zip.clj
+++ b/src/depot/zip.clj
@@ -136,10 +136,10 @@
   (and loc
        (= :token (rzip/tag loc))
        (rzip/map? (rzip/up loc))
-       (#{:deps :extra-deps :override-deps} (some-> loc
-                                                    rzip/up
-                                                    left
-                                                    rzip/sexpr))))
+       (#{:deps :default-deps :extra-deps :override-deps} (some-> loc
+                                                                  rzip/up
+                                                                  left
+                                                                  rzip/sexpr))))
 
 (defn next-lib
   "Find the next loc, depth first, that is a library name."


### PR DESCRIPTION
https://github.com/Olical/depot/issues/54

In aliases, dependencies can appear under :extra-deps, :override-deps and :default-deps.
Reference https://clojure.org/reference/deps_and_cli#_resolve_deps

The current behavior is that only :extra-deps and override-deps are checked.