### PR TITLE
Update deps version && add :git/url for git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .cpcache/
 target/
 .nrepl-port
+.calva/
+.clj-kondo/
+.lsp/

--- a/README-v1.md
+++ b/README-v1.md
@@ -42,7 +42,7 @@ Updating: deps.edn
   rewrite-clj {:mvn/version "0.6.0"} -> {:mvn/version "0.6.1"}
   cider/cider-nrepl {:mvn/version "0.17.0"} -> {:mvn/version "0.18.0"}
   clj-time {:mvn/version "0.14.4"} -> {:mvn/version "0.15.1"}
-  olical/cljs-test-runner {:sha "5a18d41648d5c3a64632b5fec07734d32cca7671"} -> {:sha "da9710b389782d4637ef114176f6e741225e16f0"}
+  olical/cljs-test-runner {:git/sha "5a18d41648d5c3a64632b5fec07734d32cca7671"} -> {:git/sha "da9710b389782d4637ef114176f6e741225e16f0"}
 ```
 
 This will leave any formatting, whitespace, and comments intact. It will update

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Updating old versions in: deps.edn
   rewrite-clj {:mvn/version "0.6.0"} -> {:mvn/version "0.6.1"}
   cider/cider-nrepl {:mvn/version "0.17.0"} -> {:mvn/version "0.18.0"}
   clj-time {:mvn/version "0.14.4"} -> {:mvn/version "0.15.1"}
-  olical/cljs-test-runner {:sha "5a18d41648d5c3a64632b5fec07734d32cca7671"} -> {:sha "da9710b389782d4637ef114176f6e741225e16f0"}
+  olical/cljs-test-runner {:git/sha "5a18d41648d5c3a64632b5fec07734d32cca7671"} -> {:git/sha "da9710b389782d4637ef114176f6e741225e16f0"}
 ```
 
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,17 +1,17 @@
 {:paths ["src"]
 
  :deps
- {org.clojure/clojure {:mvn/version "1.10.3"}
-  org.clojure/tools.deps.alpha {:mvn/version "0.11.910"}
-  org.clojure/tools.cli {:mvn/version "1.0.206"}
-  rewrite-clj/rewrite-clj {:mvn/version "0.6.1"}
-  version-clj/version-clj {:mvn/version "2.0.1"}}
+ {org.clojure/clojure {:mvn/version "1.12.1"}
+  org.clojure/tools.deps.alpha {:mvn/version "0.15.1254"}
+  org.clojure/tools.cli {:mvn/version "1.1.230"}
+  rewrite-clj/rewrite-clj {:mvn/version "1.2.50"}
+  version-clj/version-clj {:mvn/version "2.0.3"}}
 
  :aliases
  {:cider
   {:extra-paths ["dev"]
    :extra-deps {org.clojure/tools.nrepl {:mvn/version "0.2.13"}
-                cider/cider-nrepl {:mvn/version "0.26.0"}}
+                cider/cider-nrepl {:mvn/version "0.57.0"}}
    :main-opts ["-m" "depot.dev.cider"]}
 
   :prepl
@@ -19,13 +19,13 @@
 
   :test
   {:extra-deps {;; Only here to check depot functionality.
-                org.slf4j/slf4j-simple {:mvn/version "1.7.30"}
+                org.slf4j/slf4j-simple {:mvn/version "2.0.17"}
                 clj-time/clj-time {:mvn/version "0.15.2"}
-                cider/cider-nrepl {:mvn/version "0.25.5"}
+                cider/cider-nrepl {:mvn/version "0.57.0"}
                 olical/cljs-test-runner {:git/url "https://github.com/Olical/cljs-test-runner.git"
                                          :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}
 
                 ;; Actually here to run tests.
-                lambdaisland/kaocha {:mvn/version "1.0.632"}}}
+                lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
   :outdated {:replace-deps {olical/depot {:mvn/version "RELEASE"}}
              :main-opts ["-m" "depot.outdated.main"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -23,7 +23,7 @@
                 clj-time/clj-time {:mvn/version "0.15.2"}
                 cider/cider-nrepl {:mvn/version "0.57.0"}
                 olical/cljs-test-runner {:git/url "https://github.com/Olical/cljs-test-runner.git"
-                                         :sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}
+                                         :git/sha "5a18d41648d5c3a64632b5fec07734d32cca7671"}
 
                 ;; Actually here to run tests.
                 lambdaisland/kaocha {:mvn/version "1.91.1392"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure {:mvn/version "1.12.1"}
-  org.clojure/tools.deps.alpha {:mvn/version "0.15.1254"}
+  org.clojure/tools.deps {:mvn/version "0.24.1523"}
   org.clojure/tools.cli {:mvn/version "1.1.230"}
   rewrite-clj/rewrite-clj {:mvn/version "1.2.50"}
   version-clj/version-clj {:mvn/version "2.0.3"}}

--- a/src/depot/outdated.clj
+++ b/src/depot/outdated.clj
@@ -1,9 +1,9 @@
 (ns depot.outdated
   (:require [clojure.java.shell :as sh]
             [clojure.string :as str]
-            [clojure.tools.deps.alpha] ;; need for multimethods
-            [clojure.tools.deps.alpha.extensions :as ext]
-            [clojure.tools.deps.alpha.util.maven :as maven]
+            [clojure.tools.deps.extensions :as ext]
+            [clojure.tools.deps.util.maven :as maven]
+            [clojure.tools.deps.extensions.git :as git]
             [depot.zip :as dzip]
             [version-clj.core :as version])
   (:import org.apache.maven.repository.internal.MavenRepositorySystemUtils
@@ -86,12 +86,13 @@
           lines)))
 
 (defn with-git-url
-  "Add a :git/url key to coords if artifact is a GitHub artifact."
+  "Add a :git/url key to coords if artifact is a Git dependency.
+   Details: https://clojure.org/reference/deps_edn#deps_git"
   [artifact coords]
   (if (and (contains? coords :git/sha)
            (not (contains? coords :git/url)))
-    (if-let [[_ repo-name] (re-find #"io\.github\.(.*)" (str artifact))]
-      (assoc coords :git/url (str "https://github.com/" repo-name))
+    (if-let [git-url (git/auto-git-url artifact)]
+      (assoc coords :git/url git-url)
       coords)
     coords))
 

--- a/src/depot/outdated/resolve_virtual.clj
+++ b/src/depot/outdated/resolve_virtual.clj
@@ -1,7 +1,7 @@
 (ns depot.outdated.resolve-virtual
   (:require [depot.zip :as dzip]
             [depot.outdated :as outdated]
-            [clojure.tools.deps.alpha.util.maven :as maven]
+            [clojure.tools.deps.util.maven :as maven]
             [clojure.string :as str]))
 
 (defn resolve-version [lib coord {:keys [mvn/repos mvn/local-repo]}]

--- a/src/depot/outdated/update.clj
+++ b/src/depot/outdated/update.clj
@@ -1,5 +1,5 @@
 (ns depot.outdated.update
-  (:require [clojure.tools.deps.alpha :as deps.alpha]
+  (:require [clojure.tools.deps :as deps.alpha]
             [depot.zip :as dzip]
             [rewrite-clj.zip :as rzip]))
 

--- a/src/depot/zip.clj
+++ b/src/depot/zip.clj
@@ -82,7 +82,7 @@
                         left
                         zip/lefts
                         reverse
-                        (take-while rewrite-clj.node/whitespace?)
+                        (take-while rewrite-clj.reader/whitespace?)
                         reverse)
           ;; copy the whitespace nodes into the end of the map
           loc (reduce (fn [loc node]


### PR DESCRIPTION
## Summary

* Upgraded dependencies to latest version.
* Replaced deprecated org.clojure/tools.deps.alpha with org.clojure/tools.deps and updated all related usages.
* Add `:git/url` for git repo dependency.
